### PR TITLE
fix(release): regenerate and commit Cargo.lock on release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,14 +19,19 @@
 		[
 			"@semantic-release/exec",
 			{
-				"prepareCmd": "sed -i 's/^version = \"[^\"]*\"/version = \"${nextRelease.version}\"/' packages/desktop/src-tauri/Cargo.toml",
+				"prepareCmd": "sed -i 's/^version = \"[^\"]*\"/version = \"${nextRelease.version}\"/' packages/desktop/src-tauri/Cargo.toml && cargo update -p openconcho --manifest-path packages/desktop/src-tauri/Cargo.toml",
 				"publishCmd": "echo new_release_published=true >> $GITHUB_OUTPUT && echo new_release_version=${nextRelease.version} >> $GITHUB_OUTPUT"
 			}
 		],
 		[
 			"@semantic-release/git",
 			{
-				"assets": ["CHANGELOG.md", "package.json", "packages/desktop/src-tauri/Cargo.toml"],
+				"assets": [
+					"CHANGELOG.md",
+					"package.json",
+					"packages/desktop/src-tauri/Cargo.toml",
+					"packages/desktop/src-tauri/Cargo.lock"
+				],
 				"message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
 			}
 		],

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "openconcho"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
## Problem
Each release runs `sed` against `packages/desktop/src-tauri/Cargo.toml` to bump the crate version, but `Cargo.lock` is never regenerated and isn't in the `@semantic-release/git` asset list. Result: every release commit leaves `Cargo.lock` one version behind, producing dirty working trees on `main` immediately after release.

Currently visible: `Cargo.lock` lists `openconcho v0.5.1` while the toml is `0.5.2`.

## Fix
- `prepareCmd` now also runs `cargo update -p openconcho --manifest-path packages/desktop/src-tauri/Cargo.toml` to refresh the lockfile in lockstep.
- `Cargo.lock` added to `@semantic-release/git` assets so it ships in the release commit.
- Bumps the lagging `0.5.1 -> 0.5.2` entry that the 0.5.2 release missed, so this PR leaves the tree clean.

## Notes
- Requires `cargo` on the release runner (already present — release uses tauri-action).
- No code changes; release-config only.