### PR TITLE
feat(nix): add Nix flake for desktop app

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "Fast, privacy-first desktop & web UI for self-hosted Honcho";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      openconcho = pkgs.rustPlatform.buildRustPackage {
+        pname = "openconcho";
+        version = "0.8.0";
+
+        src = ./.;
+
+        cargoRoot = "packages/desktop/src-tauri";
+        buildAndTestSubdir = "packages/desktop/src-tauri";
+
+        cargoLock.lockFile = ./packages/desktop/src-tauri/Cargo.lock;
+
+        pnpmDeps = pkgs.fetchPnpmDeps {
+          pname = "openconcho-pnpm-deps";
+          version = "0.8.0";
+          src = ./.;
+          hash = "sha256-pQRyUMFyQPJ8vTm4zXazOpd0asEyz/MXHF3lKhtvDXE=";
+          pnpm = pkgs.pnpm_10;
+          fetcherVersion = 3;
+        };
+
+        nativeBuildInputs = [
+          pkgs.cargo-tauri.hook
+          pkgs.nodejs
+          pkgs.pnpmConfigHook
+          pkgs.pnpm_10
+          pkgs.pkg-config
+          pkgs.wrapGAppsHook4
+        ];
+
+        buildInputs = [
+          pkgs.openssl
+          pkgs.webkitgtk_4_1
+          pkgs.glib-networking
+          pkgs.libayatana-appindicator
+        ];
+
+        preBuild = ''
+          pnpm --filter @openconcho/web build
+        '';
+
+        meta = with pkgs.lib; {
+          description = "Fast, privacy-first desktop & web UI for self-hosted Honcho";
+          homepage = "https://github.com/offendingcommit/openconcho";
+          license = licenses.mit;
+          mainProgram = "openconcho";
+          platforms = platforms.linux;
+        };
+      };
+    in {
+      packages = {
+        inherit openconcho;
+        default = openconcho;
+      };
+
+      apps = {
+        openconcho = flake-utils.lib.mkApp {drv = openconcho;};
+        default = flake-utils.lib.mkApp {drv = openconcho;};
+      };
+    });
+}


### PR DESCRIPTION
## Summary
- Adds a Nix flake that builds the Tauri v2 desktop app
- Uses the canonical nixpkgs pattern: `cargo-tauri.hook` + `fetchPnpmDeps` + `pnpmConfigHook`
- Builds the pnpm monorepo frontend, then the Tauri Rust binary with embedded frontend assets

## Usage
```bash
nix build           # build the package
nix run             # run OpenConcho
```

## Tested
- Verified build succeeds on x86_64-linux (nixpkgs-unstable)
- Produces binary, .desktop file, and app icons