### PR TITLE
feat: side-by-side compare view across multiple instances

### DIFF
--- a/packages/web/src/api/compareQueries.ts
+++ b/packages/web/src/api/compareQueries.ts
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Instance } from "@/lib/config";
+import { createScopedClient } from "./scopedClient";
+
+function err(e: unknown): never {
+	throw new Error(typeof e === "object" ? JSON.stringify(e) : String(e));
+}
+
+// Query keys are scoped by instance.id so caches never collide across columns.
+const CK = {
+	workspaces: (instId: string, page: number, size: number) =>
+		["compare", instId, "workspaces", page, size] as const,
+	peers: (instId: string, wsId: string, page: number, size: number) =>
+		["compare", instId, "peers", wsId, page, size] as const,
+	peerRepresentation: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-representation", wsId, pId] as const,
+	peerCard: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-card", wsId, pId] as const,
+};
+
+export function useScopedWorkspaces(instance: Instance, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.workspaces(instance.id, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/list", {
+				params: { query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+	});
+}
+
+export function useScopedPeers(instance: Instance, workspaceId: string, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.peers(instance.id, workspaceId, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/{workspace_id}/peers/list", {
+				params: { path: { workspace_id: workspaceId }, query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId),
+	});
+}
+
+export function useScopedPeerRepresentation(
+	instance: Instance,
+	workspaceId: string,
+	peerId: string,
+) {
+	return useQuery({
+		queryKey: CK.peerRepresentation(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/representation",
+				{
+					params: { path: { workspace_id: workspaceId, peer_id: peerId } },
+					body: { max_conclusions: 20 },
+				},
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}
+
+export function useScopedPeerCard(instance: Instance, workspaceId: string, peerId: string) {
+	return useQuery({
+		queryKey: CK.peerCard(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.GET(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/card",
+				{ params: { path: { workspace_id: workspaceId, peer_id: peerId } } },
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}

--- a/packages/web/src/api/scopedClient.ts
+++ b/packages/web/src/api/scopedClient.ts
@@ -1,0 +1,18 @@
+import createClient from "openapi-fetch";
+import type { Instance } from "@/lib/config";
+import { httpFetch } from "@/lib/http";
+import type { paths } from "./schema.d.ts";
+
+export type ScopedClient = ReturnType<typeof createClient<paths>>;
+
+/**
+ * Create an openapi-fetch client bound to a specific instance. Use for views
+ * that need to query non-active instances (e.g. side-by-side comparison).
+ * For single-instance access, prefer `client.current` which tracks the active
+ * instance via localStorage.
+ */
+export function createScopedClient(instance: Instance): ScopedClient {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (instance.token) headers.Authorization = `Bearer ${instance.token}`;
+	return createClient<paths>({ baseUrl: instance.baseUrl, headers, fetch: httpFetch });
+}

--- a/packages/web/src/components/compare/CompareColumn.tsx
+++ b/packages/web/src/components/compare/CompareColumn.tsx
@@ -1,0 +1,210 @@
+import { X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	useScopedPeerCard,
+	useScopedPeerRepresentation,
+	useScopedPeers,
+	useScopedWorkspaces,
+} from "@/api/compareQueries";
+import type { components } from "@/api/schema.d.ts";
+import { ErrorAlert } from "@/components/shared/ErrorAlert";
+import { PeerCardViewer } from "@/components/shared/PeerCardViewer";
+import { Skeleton } from "@/components/shared/Skeleton";
+import { Caption, MonoCaption, SectionHeading } from "@/components/ui/typography";
+import { useDemo } from "@/hooks/useDemo";
+import type { Instance } from "@/lib/config";
+
+type Workspace = components["schemas"]["Workspace"];
+type Peer = components["schemas"]["Peer"];
+type Conclusion = components["schemas"]["Conclusion"];
+
+interface Props {
+	instance: Instance;
+	targetPeerName: string | undefined;
+	onRemove: () => void;
+}
+
+export function CompareColumn({ instance, targetPeerName, onRemove }: Props) {
+	const { mask } = useDemo();
+	const [workspaceId, setWorkspaceId] = useState<string>("");
+	const [peerId, setPeerId] = useState<string>("");
+
+	const workspacesQuery = useScopedWorkspaces(instance);
+	const peersQuery = useScopedPeers(instance, workspaceId);
+	const representation = useScopedPeerRepresentation(instance, workspaceId, peerId);
+	const card = useScopedPeerCard(instance, workspaceId, peerId);
+
+	const workspaces: Workspace[] = useMemo(
+		() => (workspacesQuery.data as { items?: Workspace[] } | undefined)?.items ?? [],
+		[workspacesQuery.data],
+	);
+	const peers: Peer[] = useMemo(
+		() => (peersQuery.data as { items?: Peer[] } | undefined)?.items ?? [],
+		[peersQuery.data],
+	);
+
+	// Auto-select first workspace once loaded.
+	useEffect(() => {
+		if (workspaces.length > 0 && !workspaceId) {
+			setWorkspaceId(workspaces[0].id);
+		}
+	}, [workspaces, workspaceId]);
+
+	// Auto-select peer: prefer the target name if it exists in this instance,
+	// otherwise fall back to the first peer.
+	useEffect(() => {
+		if (peers.length === 0) return;
+		if (targetPeerName) {
+			const match = peers.find((p) => p.id === targetPeerName);
+			if (match && match.id !== peerId) {
+				setPeerId(match.id);
+				return;
+			}
+			if (match) return;
+		}
+		if (!peerId) setPeerId(peers[0].id);
+	}, [peers, targetPeerName, peerId]);
+
+	const cardLines: string[] = useMemo(() => {
+		const raw = (card.data as { peer_card?: unknown } | undefined)?.peer_card;
+		if (Array.isArray(raw)) return raw as string[];
+		if (typeof raw === "string") return [raw];
+		return [];
+	}, [card.data]);
+
+	const conclusions: Conclusion[] = useMemo(() => {
+		const raw = (representation.data as { conclusions?: Conclusion[] } | undefined)?.conclusions;
+		return Array.isArray(raw) ? raw : [];
+	}, [representation.data]);
+
+	return (
+		<div
+			className="flex flex-col h-full rounded-lg overflow-hidden min-w-0"
+			style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
+		>
+			<header
+				className="px-4 py-3 flex items-center justify-between gap-2"
+				style={{ borderBottom: "1px solid var(--border)", background: "var(--bg-2)" }}
+			>
+				<div className="min-w-0 flex-1">
+					<p
+						className="text-sm font-medium truncate"
+						style={{ color: "var(--text-1)" }}
+						title={instance.name}
+					>
+						{instance.name}
+					</p>
+					<MonoCaption as="p" className="truncate" title={mask(instance.baseUrl)}>
+						{mask(instance.baseUrl.replace(/^https?:\/\//, ""))}
+					</MonoCaption>
+				</div>
+				<button
+					type="button"
+					onClick={onRemove}
+					className="w-7 h-7 rounded-md flex items-center justify-center transition-colors shrink-0 hover:opacity-80"
+					style={{ color: "var(--text-3)", background: "transparent" }}
+					title="Remove from compare"
+					aria-label={`Remove ${instance.name} from comparison`}
+				>
+					<X className="w-4 h-4" strokeWidth={1.5} />
+				</button>
+			</header>
+
+			<div className="px-4 py-3 space-y-2" style={{ borderBottom: "1px solid var(--border)" }}>
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Workspace
+					<select
+						value={workspaceId}
+						onChange={(e) => {
+							setWorkspaceId(e.target.value);
+							setPeerId("");
+						}}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+					>
+						{workspacesQuery.isLoading && <option>Loading…</option>}
+						{!workspacesQuery.isLoading && workspaces.length === 0 && (
+							<option value="">No workspaces</option>
+						)}
+						{workspaces.map((ws) => (
+							<option key={ws.id} value={ws.id}>
+								{mask(ws.id)}
+							</option>
+						))}
+					</select>
+				</label>
+
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Peer
+					<select
+						value={peerId}
+						onChange={(e) => setPeerId(e.target.value)}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+						disabled={!workspaceId}
+					>
+						{peersQuery.isLoading && <option>Loading…</option>}
+						{!peersQuery.isLoading && peers.length === 0 && <option value="">No peers</option>}
+						{peers.map((p) => (
+							<option key={p.id} value={p.id}>
+								{mask(p.id)}
+							</option>
+						))}
+					</select>
+				</label>
+			</div>
+
+			<div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+				{workspacesQuery.error && <ErrorAlert error={workspacesQuery.error} />}
+
+				{peerId && (
+					<>
+						<section>
+							<SectionHeading className="mb-2">Conclusions</SectionHeading>
+							{representation.isLoading && <Skeleton className="h-24" />}
+							{!representation.isLoading && conclusions.length === 0 && (
+								<Caption>No conclusions yet for this peer.</Caption>
+							)}
+							{conclusions.length > 0 && (
+								<ul className="space-y-1.5">
+									{conclusions.map((c, i) => (
+										<li
+											key={`${i}-${c.content.slice(0, 32)}`}
+											className="text-sm leading-relaxed px-3 py-2 rounded-md break-words"
+											style={{
+												background: "var(--bg-2)",
+												border: "1px solid var(--border)",
+												color: "var(--text-2)",
+											}}
+										>
+											{c.content}
+										</li>
+									))}
+								</ul>
+							)}
+							{conclusions.length > 0 && (
+								<Caption className="mt-2 block">
+									{conclusions.length} {conclusions.length === 1 ? "conclusion" : "conclusions"}
+								</Caption>
+							)}
+						</section>
+
+						<section>
+							<SectionHeading className="mb-2">Peer card</SectionHeading>
+							{card.isLoading && <Skeleton className="h-32" />}
+							{!card.isLoading && <PeerCardViewer lines={cardLines} />}
+						</section>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/compare/CompareView.tsx
+++ b/packages/web/src/components/compare/CompareView.tsx
@@ -1,0 +1,192 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Columns2, Plus } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Body, Caption, PageTitle } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import type { Instance } from "@/lib/config";
+import { CompareColumn } from "./CompareColumn";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export function CompareView() {
+	const navigate = useNavigate();
+	const search = useSearch({ strict: false }) as CompareSearch;
+	const { instances } = useInstances();
+
+	const selectedIds = useMemo(() => {
+		if (!search.instances) return [];
+		return search.instances.split(",").filter(Boolean);
+	}, [search.instances]);
+
+	const selected: Instance[] = useMemo(() => {
+		const lookup = new Map(instances.map((i) => [i.id, i] as const));
+		return selectedIds.map((id) => lookup.get(id)).filter((i): i is Instance => i !== undefined);
+	}, [selectedIds, instances]);
+
+	const available = useMemo(
+		() => instances.filter((i) => !selectedIds.includes(i.id)),
+		[instances, selectedIds],
+	);
+
+	const [pickerOpen, setPickerOpen] = useState(false);
+	const pickerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!pickerOpen) return;
+		function onClick(e: MouseEvent) {
+			if (!pickerRef.current?.contains(e.target as Node)) setPickerOpen(false);
+		}
+		window.addEventListener("mousedown", onClick);
+		return () => window.removeEventListener("mousedown", onClick);
+	}, [pickerOpen]);
+
+	function setInstancesSearch(ids: string[]) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, instances: ids.length > 0 ? ids.join(",") : undefined } as never,
+		});
+	}
+
+	function addInstance(id: string) {
+		setInstancesSearch([...selectedIds, id]);
+		setPickerOpen(false);
+	}
+
+	function removeInstance(id: string) {
+		setInstancesSearch(selectedIds.filter((sid) => sid !== id));
+	}
+
+	function setTargetPeer(peer: string) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, peer: peer || undefined } as never,
+		});
+	}
+
+	if (instances.length === 0) {
+		return (
+			<div className="page-container">
+				<PageTitle>Compare</PageTitle>
+				<Body className="mt-2">
+					Configure at least two Honcho instances in Settings before using compare.
+				</Body>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col h-full">
+			<div
+				className="px-6 py-4 flex items-start justify-between gap-4 flex-wrap"
+				style={{ borderBottom: "1px solid var(--border)" }}
+			>
+				<div>
+					<PageTitle>Compare</PageTitle>
+					<Caption as="p" className="mt-0.5">
+						Side-by-side view of peer representations across instances
+					</Caption>
+				</div>
+				<div className="flex items-center gap-3 flex-wrap">
+					<label
+						className="text-xs font-medium flex items-center gap-2"
+						style={{ color: "var(--text-3)" }}
+					>
+						Target peer
+						<input
+							type="text"
+							value={search.peer ?? ""}
+							onChange={(e) => setTargetPeer(e.target.value)}
+							placeholder="ben"
+							className="px-2 py-1 text-sm rounded-md font-mono"
+							style={{
+								background: "var(--bg-2)",
+								border: "1px solid var(--border)",
+								color: "var(--text-2)",
+								width: "12rem",
+							}}
+						/>
+					</label>
+
+					<div ref={pickerRef} className="relative">
+						<button
+							type="button"
+							onClick={() => setPickerOpen((v) => !v)}
+							disabled={available.length === 0}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors"
+							style={{
+								background: "var(--accent-dim)",
+								border: "1px solid var(--accent-border)",
+								color: "var(--accent-text)",
+								opacity: available.length === 0 ? 0.5 : 1,
+								cursor: available.length === 0 ? "not-allowed" : "pointer",
+							}}
+						>
+							<Plus className="w-4 h-4" strokeWidth={2} />
+							Add instance
+						</button>
+						{pickerOpen && available.length > 0 && (
+							<div
+								className="absolute right-0 top-full mt-1 rounded-lg overflow-hidden z-20 min-w-[14rem]"
+								style={{
+									background: "var(--bg-2)",
+									border: "1px solid var(--border)",
+									boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+								}}
+							>
+								{available.map((inst) => (
+									<button
+										key={inst.id}
+										type="button"
+										onClick={() => addInstance(inst.id)}
+										className="w-full flex flex-col items-start px-3 py-2 text-left transition-colors hover:opacity-80"
+										style={{ background: "transparent" }}
+									>
+										<span className="text-sm font-medium" style={{ color: "var(--text-2)" }}>
+											{inst.name}
+										</span>
+										<span
+											className="text-xs font-mono truncate w-full"
+											style={{ color: "var(--text-4)" }}
+										>
+											{inst.baseUrl.replace(/^https?:\/\//, "")}
+										</span>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{selected.length === 0 ? (
+				<div className="flex-1 flex items-center justify-center">
+					<EmptyState
+						icon={Columns2}
+						title="Pick instances to compare"
+						description="Add two or more configured Honcho instances to see their peer representations side by side."
+					/>
+				</div>
+			) : (
+				<div
+					className="flex-1 grid gap-3 px-6 py-4 overflow-x-auto"
+					style={{
+						gridTemplateColumns: `repeat(${selected.length}, minmax(20rem, 1fr))`,
+					}}
+				>
+					{selected.map((inst) => (
+						<CompareColumn
+							key={inst.id}
+							instance={inst}
+							targetPeerName={search.peer || undefined}
+							onRemove={() => removeInstance(inst.id)}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
 	Check,
 	ChevronRight,
 	ChevronsUpDown,
+	Columns2,
 	Eye,
 	EyeOff,
 	LayoutDashboard,
@@ -29,6 +30,7 @@ import { COLOR } from "@/lib/constants";
 const TOP_NAV = [
 	{ to: "/" as const, label: "Dashboard", icon: LayoutDashboard, exact: true },
 	{ to: "/workspaces" as const, label: "Workspaces", icon: Boxes, exact: false },
+	{ to: "/compare" as const, label: "Compare", icon: Columns2, exact: false },
 	{ to: "/settings" as const, label: "Settings", icon: Settings, exact: false },
 ];
 

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkspacesRouteImport } from './routes/workspaces'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ExploreRouteImport } from './routes/explore'
+import { Route as CompareRouteImport } from './routes/compare'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspacesWorkspaceIdRouteImport } from './routes/workspaces_.$workspaceId'
 import { Route as WorkspacesWorkspaceIdWebhooksRouteImport } from './routes/workspaces_.$workspaceId_.webhooks'
@@ -35,6 +36,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ExploreRoute = ExploreRouteImport.update({
   id: '/explore',
   path: '/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompareRoute = CompareRouteImport.update({
+  id: '/compare',
+  path: '/compare',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -92,6 +98,7 @@ const WorkspacesWorkspaceIdPeersPeerIdChatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -121,6 +129,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -137,6 +146,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -151,6 +161,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -165,6 +176,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -180,6 +192,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CompareRoute: typeof CompareRoute
   ExploreRoute: typeof ExploreRoute
   SettingsRoute: typeof SettingsRoute
   WorkspacesRoute: typeof WorkspacesRoute
@@ -214,6 +227,13 @@ declare module '@tanstack/react-router' {
       path: '/explore'
       fullPath: '/explore'
       preLoaderRoute: typeof ExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -284,6 +304,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CompareRoute: CompareRoute,
   ExploreRoute: ExploreRoute,
   SettingsRoute: SettingsRoute,
   WorkspacesRoute: WorkspacesRoute,

--- a/packages/web/src/routes/compare.tsx
+++ b/packages/web/src/routes/compare.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompareView } from "@/components/compare/CompareView";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export const Route = createFileRoute("/compare")({
+	validateSearch: (search: Record<string, unknown>): CompareSearch => ({
+		instances: typeof search.instances === "string" ? search.instances : undefined,
+		peer: typeof search.peer === "string" ? search.peer : undefined,
+	}),
+	component: CompareView,
+});

--- a/packages/web/src/test/compare.test.tsx
+++ b/packages/web/src/test/compare.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DemoProvider } from "@/context/DemoContext";
+import { MetadataProvider } from "@/context/MetadataContext";
+import { saveStore } from "@/lib/config";
+import { routeTree } from "@/routeTree.gen";
+
+function renderAt(initialPath: string) {
+	const router = createRouter({
+		routeTree,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+	});
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<DemoProvider>
+				<MetadataProvider>
+					{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+					<RouterProvider router={router as any} />
+				</MetadataProvider>
+			</DemoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("Compare route", () => {
+	it("prompts the user to add instances when none are selected", async () => {
+		saveStore({
+			instances: [
+				{ id: "neo", name: "Neo", baseUrl: "http://localhost:8001", token: "" },
+				{ id: "iris", name: "Iris", baseUrl: "http://localhost:8002", token: "" },
+			],
+			activeId: "neo",
+		});
+		renderAt("/compare");
+		expect(await screen.findByText(/Pick instances to compare/i)).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/test/scoped-client.test.ts
+++ b/packages/web/src/test/scoped-client.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { createScopedClient } from "@/api/scopedClient";
+import type { Instance } from "@/lib/config";
+
+vi.mock("@/lib/http", () => ({
+	httpFetch: vi.fn(async () => new Response("{}", { status: 200 })),
+}));
+
+const instance: Instance = {
+	id: "inst-1",
+	name: "Neo",
+	baseUrl: "http://localhost:8001",
+	token: "secret-token",
+};
+
+describe("createScopedClient", () => {
+	it("issues requests to the instance baseUrl", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.url).toBe("http://localhost:8001/v3/keys");
+	});
+
+	it("attaches the instance token as a Bearer Authorization header", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.headers.get("Authorization")).toBe("Bearer secret-token");
+	});
+});


### PR DESCRIPTION
## Why

Multi-instance support landed in #8 — but the interface is still "pick one
active instance at a time." For users running a fleet of self-hosted Honchos
(e.g. one per agent), the question that motivates running them is *"how do
my agents' representations of the same person differ?"* — which can't be
answered without flipping between instances and reconciling by memory.

This PR adds a `/compare` route that renders N columns, one per pinned
instance, so peer representations can be inspected side-by-side without
disturbing the active instance.

## What

**API layer**
- `createScopedClient(instance)` — openapi-fetch client bound to a specific
  instance rather than the active one. Sits next to the existing
  `client.current` pattern (no change to any existing query hook).
- `compareQueries.ts` — scoped versions of `useWorkspaces`, `usePeers`,
  `usePeerRepresentation`, `usePeerCard`. Each accepts an `Instance` and
  scopes its TanStack Query key by `instance.id` so caches don't collide
  across columns.

**UI**
- `/compare` route (top-level), search params: `instances=<comma-ids>` and
  `peer=<target-name>` for shareable/deep-linkable views.
- `CompareView` — header with target-peer input and "Add instance" dropdown
  (only shows instances not already pinned), plus the columns grid.
- `CompareColumn` — workspace selector, peer selector, peer representation
  list (top conclusions), and peer card via the existing `PeerCardViewer`.
  Auto-selects first workspace; prefers the target peer name if it exists
  in that instance, else first peer.
- Sidebar gets a `Compare` nav entry between Workspaces and Settings, using
  the `Columns2` icon.

**Tests**
- `scopedClient.test.ts` — verifies requests target the instance's baseUrl
  and attach the instance's Bearer token.
- `compare.test.tsx` — verifies the empty-state prompt renders when no
  instances are selected.

## Out of scope (potential follow-ups)

- Diff highlighting between columns (semantic diff of conclusion sets)
- Synchronized scrolling between columns
- "All peers" view (compare conclusion counts, last-dream times, etc. as a
  fleet-overview dashboard)

## Manual verification

Verified against a local fleet of 5 Honcho stacks (one per agent, ports
8001–8005). Each column's queries correctly route to its own instance's
URL (confirmed via PerformanceResourceTiming). The visual layout renders
cleanly with 5 columns side-by-side.

> Note: live data fetch requires the Honcho daemons to allow the dev origin
> in their CORS config. The existing `client.current` health check hits
> the same CORS path — this PR doesn't change that surface.

## Conventions

- Conventional commit (`feat:`)
- TypeScript strict, no `any`
- CSS variables for theme colors (no Tailwind color utilities)
- TanStack Router `as never` cast at navigate callsites
- `pnpm typecheck`, `pnpm lint`, and the new tests all pass locally