### PR TITLE
feat(web): add Fleet dashboard for cross-instance observability

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -924,12 +924,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -984,6 +1000,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2268,6 +2285,7 @@ dependencies = [
 name = "openconcho"
 version = "0.8.0"
 dependencies = [
+ "futures",
  "serde",
  "serde_json",
  "tauri",
@@ -2275,6 +2293,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-http",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -17,3 +17,5 @@ tauri-plugin-shell = "2"
 tauri-plugin-deep-link = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["net", "io-util", "time", "rt", "macros"] }
+futures = "0.3"

--- a/packages/desktop/src-tauri/src/discover.rs
+++ b/packages/desktop/src-tauri/src/discover.rs
@@ -1,0 +1,98 @@
+//! Localhost Honcho instance discovery.
+//!
+//! Probes a range of ports on 127.0.0.1 for a Honcho `/health` endpoint
+//! that returns `{"status":"ok"}`. Desktop-only feature: the browser
+//! can't port-scan due to CORS, so this lives in the Tauri Rust shell.
+
+use serde::Serialize;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+const DEFAULT_START_PORT: u16 = 8000;
+const DEFAULT_END_PORT: u16 = 8100;
+const CONNECT_TIMEOUT_MS: u64 = 150;
+const REQUEST_TIMEOUT_MS: u64 = 250;
+
+#[derive(Serialize, Debug)]
+pub struct DiscoveredInstance {
+	pub port: u16,
+	pub base_url: String,
+}
+
+async fn probe_port(port: u16) -> Option<DiscoveredInstance> {
+	let addr = format!("127.0.0.1:{}", port);
+
+	let connect = TcpStream::connect(&addr);
+	let stream = tokio::time::timeout(Duration::from_millis(CONNECT_TIMEOUT_MS), connect)
+		.await
+		.ok()?
+		.ok()?;
+
+	let mut stream = stream;
+	let req = b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+
+	let io = async {
+		stream.write_all(req).await.ok()?;
+		let mut buf = Vec::with_capacity(512);
+		stream.read_to_end(&mut buf).await.ok()?;
+		Some(buf)
+	};
+	let buf = tokio::time::timeout(Duration::from_millis(REQUEST_TIMEOUT_MS), io)
+		.await
+		.ok()??;
+
+	let body = String::from_utf8_lossy(&buf);
+	if body.contains("\"status\":\"ok\"") {
+		Some(DiscoveredInstance {
+			port,
+			base_url: format!("http://127.0.0.1:{}", port),
+		})
+	} else {
+		None
+	}
+}
+
+#[tauri::command]
+pub async fn discover_honcho_instances(
+	start_port: Option<u16>,
+	end_port: Option<u16>,
+) -> Vec<DiscoveredInstance> {
+	let start = start_port.unwrap_or(DEFAULT_START_PORT);
+	let end = end_port.unwrap_or(DEFAULT_END_PORT);
+	if end < start {
+		return Vec::new();
+	}
+
+	let probes: Vec<_> = (start..=end).map(probe_port).collect();
+	let results = futures::future::join_all(probes).await;
+	let mut found: Vec<DiscoveredInstance> = results.into_iter().flatten().collect();
+	found.sort_by_key(|d| d.port);
+	found
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn rejects_inverted_port_range() {
+		let found = discover_honcho_instances(Some(9000), Some(8000)).await;
+		assert!(found.is_empty());
+	}
+
+	#[tokio::test]
+	async fn ignores_ports_with_no_listener() {
+		// Port 1 should reliably have no listener — connect fails fast.
+		let result = probe_port(1).await;
+		assert!(result.is_none());
+	}
+
+	#[tokio::test]
+	#[ignore = "requires live Honcho stacks on 8001-8005"]
+	async fn finds_live_hermes_stacks() {
+		let found = discover_honcho_instances(Some(8000), Some(8010)).await;
+		let ports: Vec<u16> = found.iter().map(|d| d.port).collect();
+		assert_eq!(ports, vec![8001, 8002, 8003, 8004, 8005]);
+	}
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
+mod discover;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_deep_link::init())
+        .invoke_handler(tauri::generate_handler![discover::discover_honcho_instances])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/packages/web/src/api/compareQueries.ts
+++ b/packages/web/src/api/compareQueries.ts
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Instance } from "@/lib/config";
+import { createScopedClient } from "./scopedClient";
+
+function err(e: unknown): never {
+	throw new Error(typeof e === "object" ? JSON.stringify(e) : String(e));
+}
+
+// Query keys are scoped by instance.id so caches never collide across columns.
+const CK = {
+	workspaces: (instId: string, page: number, size: number) =>
+		["compare", instId, "workspaces", page, size] as const,
+	peers: (instId: string, wsId: string, page: number, size: number) =>
+		["compare", instId, "peers", wsId, page, size] as const,
+	peerRepresentation: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-representation", wsId, pId] as const,
+	peerCard: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-card", wsId, pId] as const,
+};
+
+export function useScopedWorkspaces(instance: Instance, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.workspaces(instance.id, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/list", {
+				params: { query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+	});
+}
+
+export function useScopedPeers(instance: Instance, workspaceId: string, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.peers(instance.id, workspaceId, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/{workspace_id}/peers/list", {
+				params: { path: { workspace_id: workspaceId }, query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId),
+	});
+}
+
+export function useScopedPeerRepresentation(
+	instance: Instance,
+	workspaceId: string,
+	peerId: string,
+) {
+	return useQuery({
+		queryKey: CK.peerRepresentation(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/representation",
+				{
+					params: { path: { workspace_id: workspaceId, peer_id: peerId } },
+					body: { max_conclusions: 20 },
+				},
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}
+
+export function useScopedPeerCard(instance: Instance, workspaceId: string, peerId: string) {
+	return useQuery({
+		queryKey: CK.peerCard(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.GET(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/card",
+				{ params: { path: { workspace_id: workspaceId, peer_id: peerId } } },
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}

--- a/packages/web/src/api/compareQueries.ts
+++ b/packages/web/src/api/compareQueries.ts
@@ -16,6 +16,9 @@ const CK = {
 		["compare", instId, "peer-representation", wsId, pId] as const,
 	peerCard: (instId: string, wsId: string, pId: string) =>
 		["compare", instId, "peer-card", wsId, pId] as const,
+	queueStatus: (instId: string, wsId: string) => ["compare", instId, "queue-status", wsId] as const,
+	conclusionsCount: (instId: string, wsId: string) =>
+		["compare", instId, "conclusions-count", wsId] as const,
 };
 
 export function useScopedWorkspaces(instance: Instance, page = 1, pageSize = 20) {
@@ -82,4 +85,44 @@ export function useScopedPeerCard(instance: Instance, workspaceId: string, peerI
 		},
 		enabled: Boolean(workspaceId) && Boolean(peerId),
 	});
+}
+
+// Option builders — used by both single-fetch hooks and useQueries fan-out (e.g. Fleet view).
+
+export function scopedQueueStatusOptions(instance: Instance, workspaceId: string) {
+	return {
+		queryKey: CK.queueStatus(instance.id, workspaceId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.GET("/v3/workspaces/{workspace_id}/queue/status", {
+				params: { path: { workspace_id: workspaceId } },
+			});
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId),
+		refetchInterval: 10_000,
+	} as const;
+}
+
+export function scopedConclusionsCountOptions(instance: Instance, workspaceId: string) {
+	return {
+		queryKey: CK.conclusionsCount(instance.id, workspaceId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/{workspace_id}/conclusions/list", {
+				params: { path: { workspace_id: workspaceId }, query: { page: 1, size: 1 } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId),
+	} as const;
+}
+
+export function useScopedQueueStatus(instance: Instance, workspaceId: string) {
+	return useQuery(scopedQueueStatusOptions(instance, workspaceId));
+}
+
+export function useScopedConclusionsCount(instance: Instance, workspaceId: string) {
+	return useQuery(scopedConclusionsCountOptions(instance, workspaceId));
 }

--- a/packages/web/src/api/scopedClient.ts
+++ b/packages/web/src/api/scopedClient.ts
@@ -1,0 +1,18 @@
+import createClient from "openapi-fetch";
+import type { Instance } from "@/lib/config";
+import { httpFetch } from "@/lib/http";
+import type { paths } from "./schema.d.ts";
+
+export type ScopedClient = ReturnType<typeof createClient<paths>>;
+
+/**
+ * Create an openapi-fetch client bound to a specific instance. Use for views
+ * that need to query non-active instances (e.g. side-by-side comparison).
+ * For single-instance access, prefer `client.current` which tracks the active
+ * instance via localStorage.
+ */
+export function createScopedClient(instance: Instance): ScopedClient {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (instance.token) headers.Authorization = `Bearer ${instance.token}`;
+	return createClient<paths>({ baseUrl: instance.baseUrl, headers, fetch: httpFetch });
+}

--- a/packages/web/src/components/compare/CompareColumn.tsx
+++ b/packages/web/src/components/compare/CompareColumn.tsx
@@ -1,0 +1,210 @@
+import { X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	useScopedPeerCard,
+	useScopedPeerRepresentation,
+	useScopedPeers,
+	useScopedWorkspaces,
+} from "@/api/compareQueries";
+import type { components } from "@/api/schema.d.ts";
+import { ErrorAlert } from "@/components/shared/ErrorAlert";
+import { PeerCardViewer } from "@/components/shared/PeerCardViewer";
+import { Skeleton } from "@/components/shared/Skeleton";
+import { Caption, MonoCaption, SectionHeading } from "@/components/ui/typography";
+import { useDemo } from "@/hooks/useDemo";
+import type { Instance } from "@/lib/config";
+
+type Workspace = components["schemas"]["Workspace"];
+type Peer = components["schemas"]["Peer"];
+type Conclusion = components["schemas"]["Conclusion"];
+
+interface Props {
+	instance: Instance;
+	targetPeerName: string | undefined;
+	onRemove: () => void;
+}
+
+export function CompareColumn({ instance, targetPeerName, onRemove }: Props) {
+	const { mask } = useDemo();
+	const [workspaceId, setWorkspaceId] = useState<string>("");
+	const [peerId, setPeerId] = useState<string>("");
+
+	const workspacesQuery = useScopedWorkspaces(instance);
+	const peersQuery = useScopedPeers(instance, workspaceId);
+	const representation = useScopedPeerRepresentation(instance, workspaceId, peerId);
+	const card = useScopedPeerCard(instance, workspaceId, peerId);
+
+	const workspaces: Workspace[] = useMemo(
+		() => (workspacesQuery.data as { items?: Workspace[] } | undefined)?.items ?? [],
+		[workspacesQuery.data],
+	);
+	const peers: Peer[] = useMemo(
+		() => (peersQuery.data as { items?: Peer[] } | undefined)?.items ?? [],
+		[peersQuery.data],
+	);
+
+	// Auto-select first workspace once loaded.
+	useEffect(() => {
+		if (workspaces.length > 0 && !workspaceId) {
+			setWorkspaceId(workspaces[0].id);
+		}
+	}, [workspaces, workspaceId]);
+
+	// Auto-select peer: prefer the target name if it exists in this instance,
+	// otherwise fall back to the first peer.
+	useEffect(() => {
+		if (peers.length === 0) return;
+		if (targetPeerName) {
+			const match = peers.find((p) => p.id === targetPeerName);
+			if (match && match.id !== peerId) {
+				setPeerId(match.id);
+				return;
+			}
+			if (match) return;
+		}
+		if (!peerId) setPeerId(peers[0].id);
+	}, [peers, targetPeerName, peerId]);
+
+	const cardLines: string[] = useMemo(() => {
+		const raw = (card.data as { peer_card?: unknown } | undefined)?.peer_card;
+		if (Array.isArray(raw)) return raw as string[];
+		if (typeof raw === "string") return [raw];
+		return [];
+	}, [card.data]);
+
+	const conclusions: Conclusion[] = useMemo(() => {
+		const raw = (representation.data as { conclusions?: Conclusion[] } | undefined)?.conclusions;
+		return Array.isArray(raw) ? raw : [];
+	}, [representation.data]);
+
+	return (
+		<div
+			className="flex flex-col h-full rounded-lg overflow-hidden min-w-0"
+			style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
+		>
+			<header
+				className="px-4 py-3 flex items-center justify-between gap-2"
+				style={{ borderBottom: "1px solid var(--border)", background: "var(--bg-2)" }}
+			>
+				<div className="min-w-0 flex-1">
+					<p
+						className="text-sm font-medium truncate"
+						style={{ color: "var(--text-1)" }}
+						title={instance.name}
+					>
+						{instance.name}
+					</p>
+					<MonoCaption as="p" className="truncate" title={mask(instance.baseUrl)}>
+						{mask(instance.baseUrl.replace(/^https?:\/\//, ""))}
+					</MonoCaption>
+				</div>
+				<button
+					type="button"
+					onClick={onRemove}
+					className="w-7 h-7 rounded-md flex items-center justify-center transition-colors shrink-0 hover:opacity-80"
+					style={{ color: "var(--text-3)", background: "transparent" }}
+					title="Remove from compare"
+					aria-label={`Remove ${instance.name} from comparison`}
+				>
+					<X className="w-4 h-4" strokeWidth={1.5} />
+				</button>
+			</header>
+
+			<div className="px-4 py-3 space-y-2" style={{ borderBottom: "1px solid var(--border)" }}>
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Workspace
+					<select
+						value={workspaceId}
+						onChange={(e) => {
+							setWorkspaceId(e.target.value);
+							setPeerId("");
+						}}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+					>
+						{workspacesQuery.isLoading && <option>Loading…</option>}
+						{!workspacesQuery.isLoading && workspaces.length === 0 && (
+							<option value="">No workspaces</option>
+						)}
+						{workspaces.map((ws) => (
+							<option key={ws.id} value={ws.id}>
+								{mask(ws.id)}
+							</option>
+						))}
+					</select>
+				</label>
+
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Peer
+					<select
+						value={peerId}
+						onChange={(e) => setPeerId(e.target.value)}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+						disabled={!workspaceId}
+					>
+						{peersQuery.isLoading && <option>Loading…</option>}
+						{!peersQuery.isLoading && peers.length === 0 && <option value="">No peers</option>}
+						{peers.map((p) => (
+							<option key={p.id} value={p.id}>
+								{mask(p.id)}
+							</option>
+						))}
+					</select>
+				</label>
+			</div>
+
+			<div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+				{workspacesQuery.error && <ErrorAlert error={workspacesQuery.error} />}
+
+				{peerId && (
+					<>
+						<section>
+							<SectionHeading className="mb-2">Conclusions</SectionHeading>
+							{representation.isLoading && <Skeleton className="h-24" />}
+							{!representation.isLoading && conclusions.length === 0 && (
+								<Caption>No conclusions yet for this peer.</Caption>
+							)}
+							{conclusions.length > 0 && (
+								<ul className="space-y-1.5">
+									{conclusions.map((c, i) => (
+										<li
+											key={`${i}-${c.content.slice(0, 32)}`}
+											className="text-sm leading-relaxed px-3 py-2 rounded-md break-words"
+											style={{
+												background: "var(--bg-2)",
+												border: "1px solid var(--border)",
+												color: "var(--text-2)",
+											}}
+										>
+											{c.content}
+										</li>
+									))}
+								</ul>
+							)}
+							{conclusions.length > 0 && (
+								<Caption className="mt-2 block">
+									{conclusions.length} {conclusions.length === 1 ? "conclusion" : "conclusions"}
+								</Caption>
+							)}
+						</section>
+
+						<section>
+							<SectionHeading className="mb-2">Peer card</SectionHeading>
+							{card.isLoading && <Skeleton className="h-32" />}
+							{!card.isLoading && <PeerCardViewer lines={cardLines} />}
+						</section>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/compare/CompareView.tsx
+++ b/packages/web/src/components/compare/CompareView.tsx
@@ -1,0 +1,192 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Columns2, Plus } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Body, Caption, PageTitle } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import type { Instance } from "@/lib/config";
+import { CompareColumn } from "./CompareColumn";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export function CompareView() {
+	const navigate = useNavigate();
+	const search = useSearch({ strict: false }) as CompareSearch;
+	const { instances } = useInstances();
+
+	const selectedIds = useMemo(() => {
+		if (!search.instances) return [];
+		return search.instances.split(",").filter(Boolean);
+	}, [search.instances]);
+
+	const selected: Instance[] = useMemo(() => {
+		const lookup = new Map(instances.map((i) => [i.id, i] as const));
+		return selectedIds.map((id) => lookup.get(id)).filter((i): i is Instance => i !== undefined);
+	}, [selectedIds, instances]);
+
+	const available = useMemo(
+		() => instances.filter((i) => !selectedIds.includes(i.id)),
+		[instances, selectedIds],
+	);
+
+	const [pickerOpen, setPickerOpen] = useState(false);
+	const pickerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!pickerOpen) return;
+		function onClick(e: MouseEvent) {
+			if (!pickerRef.current?.contains(e.target as Node)) setPickerOpen(false);
+		}
+		window.addEventListener("mousedown", onClick);
+		return () => window.removeEventListener("mousedown", onClick);
+	}, [pickerOpen]);
+
+	function setInstancesSearch(ids: string[]) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, instances: ids.length > 0 ? ids.join(",") : undefined } as never,
+		});
+	}
+
+	function addInstance(id: string) {
+		setInstancesSearch([...selectedIds, id]);
+		setPickerOpen(false);
+	}
+
+	function removeInstance(id: string) {
+		setInstancesSearch(selectedIds.filter((sid) => sid !== id));
+	}
+
+	function setTargetPeer(peer: string) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, peer: peer || undefined } as never,
+		});
+	}
+
+	if (instances.length === 0) {
+		return (
+			<div className="page-container">
+				<PageTitle>Compare</PageTitle>
+				<Body className="mt-2">
+					Configure at least two Honcho instances in Settings before using compare.
+				</Body>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col h-full">
+			<div
+				className="px-6 py-4 flex items-start justify-between gap-4 flex-wrap"
+				style={{ borderBottom: "1px solid var(--border)" }}
+			>
+				<div>
+					<PageTitle>Compare</PageTitle>
+					<Caption as="p" className="mt-0.5">
+						Side-by-side view of peer representations across instances
+					</Caption>
+				</div>
+				<div className="flex items-center gap-3 flex-wrap">
+					<label
+						className="text-xs font-medium flex items-center gap-2"
+						style={{ color: "var(--text-3)" }}
+					>
+						Target peer
+						<input
+							type="text"
+							value={search.peer ?? ""}
+							onChange={(e) => setTargetPeer(e.target.value)}
+							placeholder="ben"
+							className="px-2 py-1 text-sm rounded-md font-mono"
+							style={{
+								background: "var(--bg-2)",
+								border: "1px solid var(--border)",
+								color: "var(--text-2)",
+								width: "12rem",
+							}}
+						/>
+					</label>
+
+					<div ref={pickerRef} className="relative">
+						<button
+							type="button"
+							onClick={() => setPickerOpen((v) => !v)}
+							disabled={available.length === 0}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors"
+							style={{
+								background: "var(--accent-dim)",
+								border: "1px solid var(--accent-border)",
+								color: "var(--accent-text)",
+								opacity: available.length === 0 ? 0.5 : 1,
+								cursor: available.length === 0 ? "not-allowed" : "pointer",
+							}}
+						>
+							<Plus className="w-4 h-4" strokeWidth={2} />
+							Add instance
+						</button>
+						{pickerOpen && available.length > 0 && (
+							<div
+								className="absolute right-0 top-full mt-1 rounded-lg overflow-hidden z-20 min-w-[14rem]"
+								style={{
+									background: "var(--bg-2)",
+									border: "1px solid var(--border)",
+									boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+								}}
+							>
+								{available.map((inst) => (
+									<button
+										key={inst.id}
+										type="button"
+										onClick={() => addInstance(inst.id)}
+										className="w-full flex flex-col items-start px-3 py-2 text-left transition-colors hover:opacity-80"
+										style={{ background: "transparent" }}
+									>
+										<span className="text-sm font-medium" style={{ color: "var(--text-2)" }}>
+											{inst.name}
+										</span>
+										<span
+											className="text-xs font-mono truncate w-full"
+											style={{ color: "var(--text-4)" }}
+										>
+											{inst.baseUrl.replace(/^https?:\/\//, "")}
+										</span>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{selected.length === 0 ? (
+				<div className="flex-1 flex items-center justify-center">
+					<EmptyState
+						icon={Columns2}
+						title="Pick instances to compare"
+						description="Add two or more configured Honcho instances to see their peer representations side by side."
+					/>
+				</div>
+			) : (
+				<div
+					className="flex-1 grid gap-3 px-6 py-4 overflow-x-auto"
+					style={{
+						gridTemplateColumns: `repeat(${selected.length}, minmax(20rem, 1fr))`,
+					}}
+				>
+					{selected.map((inst) => (
+						<CompareColumn
+							key={inst.id}
+							instance={inst}
+							targetPeerName={search.peer || undefined}
+							onRemove={() => removeInstance(inst.id)}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/fleet/FleetDashboard.tsx
+++ b/packages/web/src/components/fleet/FleetDashboard.tsx
@@ -1,0 +1,177 @@
+import { Link } from "@tanstack/react-router";
+import { motion } from "framer-motion";
+import { Network, Server, Settings as SettingsIcon } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Body, PageTitle, SectionHeading } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import { COLOR } from "@/lib/constants";
+import { formatCount } from "@/lib/utils";
+import { FleetRow } from "./FleetRow";
+import {
+	computeFleetAggregates,
+	DEFAULT_ROW_METRICS,
+	type FleetRowMetrics,
+} from "./fleetAggregates";
+
+export function FleetDashboard() {
+	const { instances } = useInstances();
+	const [metricsById, setMetricsById] = useState<Record<string, FleetRowMetrics>>({});
+
+	const setMetrics = useCallback((id: string, m: FleetRowMetrics) => {
+		setMetricsById((prev) => ({ ...prev, [id]: m }));
+	}, []);
+
+	const rows = useMemo(
+		() => instances.map((i) => metricsById[i.id] ?? DEFAULT_ROW_METRICS),
+		[instances, metricsById],
+	);
+	const agg = useMemo(() => computeFleetAggregates(rows), [rows]);
+
+	if (instances.length === 0) {
+		return (
+			<div className="page-container page-container--xl">
+				<EmptyState
+					icon={Network}
+					title="No instances configured"
+					description="Add at least one Honcho instance in Settings to use the Fleet view."
+					action={
+						<Link
+							to="/settings"
+							className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md"
+							style={{
+								background: "var(--accent-dim)",
+								border: "1px solid var(--accent-border)",
+								color: "var(--accent-text)",
+							}}
+						>
+							<SettingsIcon className="w-4 h-4" strokeWidth={1.5} />
+							Go to Settings
+						</Link>
+					}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="page-container page-container--xl">
+			<motion.div initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} className="mb-8">
+				<div className="flex items-center gap-2 mb-1">
+					<Network className="w-5 h-5" style={{ color: "var(--accent)" }} strokeWidth={1.5} />
+					<PageTitle>Fleet</PageTitle>
+					<span
+						className="ml-1 text-xs font-mono px-2 py-0.5 rounded-full"
+						style={{
+							background: COLOR.accentSubtle,
+							color: COLOR.accentText,
+							border: `1px solid ${COLOR.accentBorder}`,
+						}}
+					>
+						{agg.totalInstances} agent{agg.totalInstances !== 1 ? "s" : ""}
+					</span>
+				</div>
+				<Body className="leading-none">Cross-instance overview of all configured agents</Body>
+			</motion.div>
+
+			<motion.div
+				initial={{ opacity: 0, y: 8 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ delay: 0.05 }}
+				className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4"
+			>
+				<MetricCard label="Workspaces" value={agg.totalWorkspaces} />
+				<MetricCard label="Conclusions" value={agg.totalConclusions} accent />
+				<MetricCard
+					label="Healthy"
+					value={agg.healthyCount}
+					total={agg.totalInstances}
+					color={agg.healthyCount === agg.totalInstances ? COLOR.success : COLOR.warning}
+				/>
+				<MetricCard
+					label="Unreachable"
+					value={agg.unreachableCount}
+					color={agg.unreachableCount > 0 ? COLOR.destructive : "var(--text-3)"}
+				/>
+			</motion.div>
+
+			<motion.div
+				initial={{ opacity: 0, y: 8 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ delay: 0.12 }}
+				className="rounded-xl theme-card overflow-hidden"
+			>
+				<div
+					className="flex items-center gap-2 px-4 py-3"
+					style={{ borderBottom: "1px solid var(--border)" }}
+				>
+					<Server className="w-4 h-4" style={{ color: "var(--accent)" }} strokeWidth={1.5} />
+					<SectionHeading className="mb-0">Agents</SectionHeading>
+					<span className="text-xs ml-1" style={{ color: "var(--text-4)" }}>
+						all configured instances · queue updates every 10s
+					</span>
+				</div>
+
+				<div className="overflow-x-auto">
+					<table className="w-full text-xs">
+						<thead>
+							<tr style={{ background: "var(--bg-3)" }}>
+								<th className="py-2 px-4 font-medium text-left" style={{ color: "var(--text-3)" }}>
+									Agent
+								</th>
+								<th className="py-2 px-4 font-medium text-right" style={{ color: "var(--text-3)" }}>
+									Workspaces
+								</th>
+								<th className="py-2 px-4 font-medium text-right" style={{ color: "var(--text-3)" }}>
+									Conclusions
+								</th>
+								<th
+									className="py-2 px-4 font-medium text-right"
+									style={{ color: "var(--text-3)" }}
+									title="Active / Pending queue work units"
+								>
+									Queue (a/p)
+								</th>
+								<th className="py-2 px-4 font-medium text-right" style={{ color: "var(--text-3)" }}>
+									Last seen
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{instances.map((inst) => (
+								<FleetRow key={inst.id} instance={inst} onMetrics={setMetrics} />
+							))}
+						</tbody>
+					</table>
+				</div>
+			</motion.div>
+		</div>
+	);
+}
+
+interface MetricCardProps {
+	label: string;
+	value: number;
+	total?: number;
+	color?: string;
+	accent?: boolean;
+}
+
+function MetricCard({ label, value, total, color, accent }: MetricCardProps) {
+	const valueColor = color ?? (accent ? COLOR.accentText : "var(--text-1)");
+	return (
+		<div className="rounded-xl p-4 theme-card">
+			<div className="text-2xl font-semibold font-mono" style={{ color: valueColor }}>
+				{formatCount(value)}
+				{total !== undefined && (
+					<span className="text-base ml-1" style={{ color: "var(--text-4)" }}>
+						/ {formatCount(total)}
+					</span>
+				)}
+			</div>
+			<div className="text-xs mt-0.5" style={{ color: "var(--text-3)" }}>
+				{label}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/fleet/FleetRow.tsx
+++ b/packages/web/src/components/fleet/FleetRow.tsx
@@ -1,0 +1,192 @@
+import { useQueries } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import { CircleDot } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import {
+	scopedConclusionsCountOptions,
+	scopedQueueStatusOptions,
+	useScopedWorkspaces,
+} from "@/api/compareQueries";
+import type { components } from "@/api/schema.d.ts";
+import { HealthDot } from "@/components/shared/HealthDot";
+import { useDemo } from "@/hooks/useDemo";
+import type { Instance } from "@/lib/config";
+import { COLOR } from "@/lib/constants";
+import { formatCount } from "@/lib/utils";
+import type { FleetRowMetrics } from "./fleetAggregates";
+
+type Workspace = components["schemas"]["Workspace"];
+type QueueStatus = components["schemas"]["QueueStatus"];
+type ConclusionPage = components["schemas"]["Page_Conclusion_"];
+
+interface Props {
+	instance: Instance;
+	onMetrics: (id: string, metrics: FleetRowMetrics) => void;
+}
+
+function shallowEqualMetrics(a: FleetRowMetrics, b: FleetRowMetrics): boolean {
+	return (
+		a.workspaceCount === b.workspaceCount &&
+		a.conclusionCount === b.conclusionCount &&
+		a.queueActive === b.queueActive &&
+		a.queuePending === b.queuePending &&
+		a.lastSeen === b.lastSeen &&
+		a.health === b.health
+	);
+}
+
+function formatRelative(ts: number | null): string {
+	if (!ts) return "—";
+	const seconds = Math.round((Date.now() - ts) / 1000);
+	if (seconds < 5) return "just now";
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.round(hours / 24);
+	return `${days}d ago`;
+}
+
+export function FleetRow({ instance, onMetrics }: Props) {
+	const { mask } = useDemo();
+	const workspacesQ = useScopedWorkspaces(instance, 1, 100);
+
+	const workspaces: Workspace[] = useMemo(
+		() => (workspacesQ.data as { items?: Workspace[] } | undefined)?.items ?? [],
+		[workspacesQ.data],
+	);
+	const totalWorkspaces =
+		(workspacesQ.data as { total?: number } | undefined)?.total ?? workspaces.length;
+
+	const queueResults = useQueries({
+		queries: workspaces.map((ws) => scopedQueueStatusOptions(instance, ws.id)),
+	});
+	const conclusionsResults = useQueries({
+		queries: workspaces.map((ws) => scopedConclusionsCountOptions(instance, ws.id)),
+	});
+
+	const queueActive = queueResults.reduce(
+		(s, q) => s + ((q.data as QueueStatus | undefined)?.in_progress_work_units ?? 0),
+		0,
+	);
+	const queuePending = queueResults.reduce(
+		(s, q) => s + ((q.data as QueueStatus | undefined)?.pending_work_units ?? 0),
+		0,
+	);
+	const conclusionCount = conclusionsResults.reduce(
+		(s, c) => s + ((c.data as ConclusionPage | undefined)?.total ?? 0),
+		0,
+	);
+
+	const health: FleetRowMetrics["health"] = workspacesQ.isError
+		? "unreachable"
+		: workspacesQ.isSuccess
+			? "ok"
+			: "loading";
+	const lastSeen = workspacesQ.dataUpdatedAt > 0 ? workspacesQ.dataUpdatedAt : null;
+
+	const isActive = queueActive > 0 || queuePending > 0;
+	const isLoading =
+		workspacesQ.isLoading ||
+		queueResults.some((q) => q.isLoading) ||
+		conclusionsResults.some((c) => c.isLoading);
+
+	const metrics: FleetRowMetrics = useMemo(
+		() => ({
+			workspaceCount: totalWorkspaces,
+			conclusionCount,
+			queueActive,
+			queuePending,
+			lastSeen,
+			health,
+		}),
+		[totalWorkspaces, conclusionCount, queueActive, queuePending, lastSeen, health],
+	);
+
+	const lastReported = useRef<FleetRowMetrics | null>(null);
+	useEffect(() => {
+		if (lastReported.current && shallowEqualMetrics(lastReported.current, metrics)) return;
+		lastReported.current = metrics;
+		onMetrics(instance.id, metrics);
+	}, [instance.id, metrics, onMetrics]);
+
+	const hostname = instance.baseUrl.replace(/^https?:\/\//, "");
+
+	return (
+		<tr
+			data-testid={`fleet-row-${instance.id}`}
+			style={{
+				borderTop: "1px solid var(--border)",
+				background: isActive ? COLOR.warningDim : undefined,
+			}}
+		>
+			<td className="py-2.5 px-4">
+				<div className="flex items-center gap-2 min-w-0">
+					<HealthDot
+						status={health === "ok" ? "ok" : health === "unreachable" ? "unreachable" : "checking"}
+					/>
+					<div className="min-w-0">
+						<div className="text-sm font-medium truncate" style={{ color: "var(--text-1)" }}>
+							{instance.name}
+						</div>
+						<div
+							className="text-xs font-mono truncate max-w-[16rem]"
+							style={{ color: "var(--text-4)" }}
+							title={mask(hostname)}
+						>
+							{mask(hostname)}
+						</div>
+					</div>
+				</div>
+			</td>
+
+			<td className="py-2.5 px-4 text-right font-mono text-xs" style={{ color: "var(--text-2)" }}>
+				{workspacesQ.isLoading ? "—" : formatCount(totalWorkspaces)}
+			</td>
+
+			<td className="py-2.5 px-4 text-right font-mono text-xs" style={{ color: "var(--text-2)" }}>
+				{isLoading ? "—" : formatCount(conclusionCount)}
+			</td>
+
+			<td className="py-2.5 px-4 text-right">
+				{isLoading ? (
+					<span className="text-xs font-mono" style={{ color: "var(--text-4)" }}>
+						…
+					</span>
+				) : (
+					<div className="flex items-center justify-end gap-1.5">
+						{isActive ? (
+							<motion.div
+								animate={{ opacity: [0.5, 1, 0.5] }}
+								transition={{ duration: 1.5, repeat: Number.POSITIVE_INFINITY }}
+							>
+								<CircleDot className="w-3 h-3" style={{ color: COLOR.warning }} strokeWidth={2} />
+							</motion.div>
+						) : (
+							<CircleDot
+								className="w-3 h-3"
+								style={{ color: health === "ok" ? COLOR.success : "var(--text-4)" }}
+								strokeWidth={2}
+							/>
+						)}
+						<span
+							className="text-xs font-medium font-mono"
+							style={{ color: isActive ? COLOR.warning : "var(--text-3)" }}
+						>
+							{isActive ? `${formatCount(queueActive)}/${formatCount(queuePending)}` : "idle"}
+						</span>
+					</div>
+				)}
+			</td>
+
+			<td
+				className="py-2.5 px-4 text-right text-xs font-mono"
+				style={{ color: "var(--text-4)" }}
+				title={lastSeen ? new Date(lastSeen).toLocaleString() : undefined}
+			>
+				{health === "unreachable" ? "unreachable" : formatRelative(lastSeen)}
+			</td>
+		</tr>
+	);
+}

--- a/packages/web/src/components/fleet/fleetAggregates.ts
+++ b/packages/web/src/components/fleet/fleetAggregates.ts
@@ -1,0 +1,43 @@
+export type FleetHealth = "ok" | "unreachable" | "loading";
+
+export interface FleetRowMetrics {
+	workspaceCount: number;
+	conclusionCount: number;
+	queueActive: number;
+	queuePending: number;
+	lastSeen: number | null;
+	health: FleetHealth;
+}
+
+export interface FleetAggregates {
+	totalInstances: number;
+	totalWorkspaces: number;
+	totalConclusions: number;
+	totalQueueActive: number;
+	totalQueuePending: number;
+	healthyCount: number;
+	unreachableCount: number;
+	loadingCount: number;
+}
+
+export const DEFAULT_ROW_METRICS: FleetRowMetrics = {
+	workspaceCount: 0,
+	conclusionCount: 0,
+	queueActive: 0,
+	queuePending: 0,
+	lastSeen: null,
+	health: "loading",
+};
+
+export function computeFleetAggregates(rows: FleetRowMetrics[]): FleetAggregates {
+	return {
+		totalInstances: rows.length,
+		totalWorkspaces: rows.reduce((s, r) => s + r.workspaceCount, 0),
+		totalConclusions: rows.reduce((s, r) => s + r.conclusionCount, 0),
+		totalQueueActive: rows.reduce((s, r) => s + r.queueActive, 0),
+		totalQueuePending: rows.reduce((s, r) => s + r.queuePending, 0),
+		healthyCount: rows.filter((r) => r.health === "ok").length,
+		unreachableCount: rows.filter((r) => r.health === "unreachable").length,
+		loadingCount: rows.filter((r) => r.health === "loading").length,
+	};
+}

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
 	Check,
 	ChevronRight,
 	ChevronsUpDown,
+	Columns2,
 	Eye,
 	EyeOff,
 	LayoutDashboard,
@@ -29,6 +30,7 @@ import { COLOR } from "@/lib/constants";
 const TOP_NAV = [
 	{ to: "/" as const, label: "Dashboard", icon: LayoutDashboard, exact: true },
 	{ to: "/workspaces" as const, label: "Workspaces", icon: Boxes, exact: false },
+	{ to: "/compare" as const, label: "Compare", icon: Columns2, exact: false },
 	{ to: "/settings" as const, label: "Settings", icon: Settings, exact: false },
 ];
 

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
 	Lightbulb,
 	MessageSquare,
 	Moon,
+	Network,
 	Settings,
 	Sun,
 	Users,
@@ -29,6 +30,7 @@ import { COLOR } from "@/lib/constants";
 
 const TOP_NAV = [
 	{ to: "/" as const, label: "Dashboard", icon: LayoutDashboard, exact: true },
+	{ to: "/fleet" as const, label: "Fleet", icon: Network, exact: false },
 	{ to: "/workspaces" as const, label: "Workspaces", icon: Boxes, exact: false },
 	{ to: "/compare" as const, label: "Compare", icon: Columns2, exact: false },
 	{ to: "/settings" as const, label: "Settings", icon: Settings, exact: false },

--- a/packages/web/src/components/settings/DiscoveredInstances.tsx
+++ b/packages/web/src/components/settings/DiscoveredInstances.tsx
@@ -1,0 +1,209 @@
+import { motion } from "framer-motion";
+import { Loader, RefreshCw, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Muted } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import { COLOR } from "@/lib/constants";
+import {
+	type DiscoveredInstance,
+	discoverHonchoInstances,
+	suggestNameForInstance,
+} from "@/lib/discovery";
+
+interface Row {
+	discovered: DiscoveredInstance;
+	suggestedName: string;
+	checked: boolean;
+}
+
+interface Props {
+	/** If true, scan as soon as the component mounts. */
+	autoRun?: boolean;
+	/** Called after the user has added at least one instance. */
+	onAdded?: () => void;
+}
+
+export function DiscoveredInstances({ autoRun = false, onAdded }: Props) {
+	const { instances, add, activate } = useInstances();
+	const [scanning, setScanning] = useState(false);
+	const [hasScanned, setHasScanned] = useState(false);
+	const [rows, setRows] = useState<Row[]>([]);
+
+	const existingBaseUrls = useMemo(
+		() => new Set(instances.map((i) => i.baseUrl.replace(/\/+$/, "").toLowerCase())),
+		[instances],
+	);
+
+	const runScan = useCallback(async () => {
+		setScanning(true);
+		try {
+			const found = await discoverHonchoInstances();
+			const fresh = found.filter(
+				(d) => !existingBaseUrls.has(d.base_url.replace(/\/+$/, "").toLowerCase()),
+			);
+			const named = await Promise.all(
+				fresh.map(async (d) => {
+					const name = (await suggestNameForInstance(d.base_url)) ?? `Honcho :${d.port}`;
+					return { discovered: d, suggestedName: name, checked: true } satisfies Row;
+				}),
+			);
+			setRows(named);
+		} finally {
+			setScanning(false);
+			setHasScanned(true);
+		}
+	}, [existingBaseUrls]);
+
+	useEffect(() => {
+		if (autoRun) void runScan();
+	}, [autoRun, runScan]);
+
+	function setRowChecked(port: number, checked: boolean) {
+		setRows((r) => r.map((row) => (row.discovered.port === port ? { ...row, checked } : row)));
+	}
+
+	function setRowName(port: number, suggestedName: string) {
+		setRows((r) =>
+			r.map((row) => (row.discovered.port === port ? { ...row, suggestedName } : row)),
+		);
+	}
+
+	function addSelected() {
+		const selected = rows.filter((r) => r.checked);
+		if (selected.length === 0) return;
+		let firstId: string | null = null;
+		for (const row of selected) {
+			const created = add({
+				name: row.suggestedName.trim() || `Honcho :${row.discovered.port}`,
+				baseUrl: row.discovered.base_url,
+				token: "",
+			});
+			if (firstId === null) firstId = created.id;
+		}
+		if (firstId) activate(firstId);
+		setRows([]);
+		onAdded?.();
+	}
+
+	const selectedCount = rows.filter((r) => r.checked).length;
+
+	return (
+		<div
+			className="rounded-2xl p-5 space-y-3"
+			style={{ background: "var(--bg-2)", border: "1px solid var(--border)" }}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<div className="flex items-center gap-2">
+					<Sparkles
+						className="w-4 h-4 shrink-0"
+						style={{ color: COLOR.accentText }}
+						strokeWidth={1.5}
+					/>
+					<div>
+						<p className="text-sm font-medium" style={{ color: "var(--text-1)" }}>
+							Discover local Honcho instances
+						</p>
+						<Muted className="text-xs">Scans 127.0.0.1:8000–8100 for running instances</Muted>
+					</div>
+				</div>
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => void runScan()}
+					disabled={scanning}
+					className="rounded-xl px-3 py-2"
+					title="Rescan"
+				>
+					{scanning ? (
+						<motion.div
+							animate={{ rotate: 360 }}
+							transition={{
+								duration: 1,
+								repeat: Number.POSITIVE_INFINITY,
+								ease: "linear",
+							}}
+						>
+							<Loader className="w-4 h-4" strokeWidth={1.5} />
+						</motion.div>
+					) : (
+						<RefreshCw className="w-4 h-4" strokeWidth={1.5} />
+					)}
+					<span className="hidden sm:inline ml-1.5 text-xs">
+						{scanning ? "Scanning…" : "Rescan"}
+					</span>
+				</Button>
+			</div>
+
+			{hasScanned && !scanning && rows.length === 0 && (
+				<Muted className="text-xs">
+					No new instances found. Add one manually below if you know its URL.
+				</Muted>
+			)}
+
+			{rows.length > 0 && (
+				<>
+					<div className="space-y-1.5">
+						{rows.map((row) => (
+							<DiscoveredRow
+								key={row.discovered.port}
+								row={row}
+								onCheck={(c) => setRowChecked(row.discovered.port, c)}
+								onRename={(n) => setRowName(row.discovered.port, n)}
+							/>
+						))}
+					</div>
+					<Button
+						type="button"
+						variant="accent"
+						onClick={addSelected}
+						disabled={selectedCount === 0}
+						className="w-full rounded-xl py-2.5"
+					>
+						{selectedCount === 0
+							? "Select at least one"
+							: `Add ${selectedCount} instance${selectedCount === 1 ? "" : "s"}`}
+					</Button>
+				</>
+			)}
+		</div>
+	);
+}
+
+interface DiscoveredRowProps {
+	row: Row;
+	onCheck: (checked: boolean) => void;
+	onRename: (name: string) => void;
+}
+
+function DiscoveredRow({ row, onCheck, onRename }: DiscoveredRowProps) {
+	return (
+		<div
+			className="flex items-center gap-2.5 rounded-xl px-3 py-2"
+			style={{
+				background: row.checked ? "var(--surface)" : "transparent",
+				border: `1px solid ${row.checked ? "var(--accent-border)" : "var(--border)"}`,
+			}}
+		>
+			<input
+				type="checkbox"
+				checked={row.checked}
+				onChange={(e) => onCheck(e.target.checked)}
+				className="w-4 h-4 shrink-0 cursor-pointer"
+				aria-label={`Select ${row.suggestedName}`}
+			/>
+			<input
+				type="text"
+				value={row.suggestedName}
+				onChange={(e) => onRename(e.target.value)}
+				className="flex-1 min-w-0 bg-transparent text-sm font-medium border-0 outline-none px-1 py-0.5 rounded"
+				style={{ color: "var(--text-1)" }}
+				aria-label={`Name for instance on port ${row.discovered.port}`}
+				disabled={!row.checked}
+			/>
+			<span className="text-xs font-mono shrink-0" style={{ color: "var(--text-4)" }}>
+				:{row.discovered.port}
+			</span>
+		</div>
+	);
+}

--- a/packages/web/src/components/settings/InstancesManager.tsx
+++ b/packages/web/src/components/settings/InstancesManager.tsx
@@ -1,12 +1,24 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { Check, ChevronRight, Cloud, Pencil, Plus, Server, Sparkles, Trash2 } from "lucide-react";
+import {
+	Check,
+	ChevronRight,
+	Cloud,
+	Pencil,
+	Plus,
+	Radar,
+	Server,
+	Sparkles,
+	Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
+import { DiscoveredInstances } from "@/components/settings/DiscoveredInstances";
 import { type ConnectionPreset, SettingsForm } from "@/components/settings/SettingsForm";
 import { Button } from "@/components/ui/button";
 import { Muted } from "@/components/ui/typography";
 import { useInstances } from "@/hooks/useInstances";
 import { checkConnection, HONCHO_CLOUD_URL, type Instance, isCloudInstance } from "@/lib/config";
 import { COLOR } from "@/lib/constants";
+import { isTauri } from "@/lib/discovery";
 
 const LOCALHOST_PROBE_URL = "http://localhost:8000";
 
@@ -14,7 +26,8 @@ type Mode =
 	| { kind: "list" }
 	| { kind: "choose-type" }
 	| { kind: "create"; preset: ConnectionPreset }
-	| { kind: "edit"; id: string };
+	| { kind: "edit"; id: string }
+	| { kind: "discover" };
 
 interface InstancesManagerProps {
 	onActivated?: () => void;
@@ -23,16 +36,44 @@ interface InstancesManagerProps {
 export function InstancesManager({ onActivated }: InstancesManagerProps) {
 	const { instances, activeId, activate, remove } = useInstances();
 	const isFirstRun = instances.length === 0;
+	const inTauri = isTauri();
 	const [mode, setMode] = useState<Mode>(isFirstRun ? { kind: "choose-type" } : { kind: "list" });
 
 	const backFromCreate = () => setMode(isFirstRun ? { kind: "choose-type" } : { kind: "list" });
 
+	if (mode.kind === "discover") {
+		return (
+			<div className="space-y-3">
+				<DiscoveredInstances autoRun onAdded={() => setMode({ kind: "list" })} />
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => setMode({ kind: "list" })}
+					className="w-full py-2.5 px-4 rounded-xl"
+				>
+					Back
+				</Button>
+			</div>
+		);
+	}
+
 	if (mode.kind === "choose-type") {
 		return (
-			<ConnectionTypeChooser
-				onPick={(preset) => setMode({ kind: "create", preset })}
-				onCancel={isFirstRun ? undefined : () => setMode({ kind: "list" })}
-			/>
+			<div className="space-y-3">
+				{inTauri && (
+					<DiscoveredInstances
+						autoRun
+						onAdded={() => {
+							setMode({ kind: "list" });
+							onActivated?.();
+						}}
+					/>
+				)}
+				<ConnectionTypeChooser
+					onPick={(preset) => setMode({ kind: "create", preset })}
+					onCancel={isFirstRun ? undefined : () => setMode({ kind: "list" })}
+				/>
+			</div>
 		);
 	}
 
@@ -81,6 +122,18 @@ export function InstancesManager({ onActivated }: InstancesManagerProps) {
 					/>
 				))}
 			</div>
+
+			{inTauri && (
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => setMode({ kind: "discover" })}
+					className="w-full py-2.5 px-4 rounded-xl flex items-center justify-center gap-2"
+				>
+					<Radar className="w-4 h-4" strokeWidth={1.5} />
+					Discover instances
+				</Button>
+			)}
 
 			<Button
 				type="button"

--- a/packages/web/src/lib/discovery.ts
+++ b/packages/web/src/lib/discovery.ts
@@ -1,0 +1,57 @@
+import { httpFetch } from "@/lib/http";
+
+export interface DiscoveredInstance {
+	port: number;
+	base_url: string;
+}
+
+export function isTauri(): boolean {
+	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Probe localhost ports for running Honcho instances. Desktop-only — the web
+ * build can't port-scan due to CORS, so this returns an empty list when not
+ * running inside Tauri.
+ */
+export async function discoverHonchoInstances(): Promise<DiscoveredInstance[]> {
+	if (!isTauri()) return [];
+	const { invoke } = await import("@tauri-apps/api/core");
+	return invoke<DiscoveredInstance[]>("discover_honcho_instances");
+}
+
+/**
+ * Derive a friendly agent name from a workspace ID. Honcho workspaces follow
+ * the convention `<agent>-<camp>` (e.g. "neo-personal", "jeeves-codewalnut"),
+ * so we take the prefix and capitalize it. Falls back to the full ID if no
+ * hyphen is present.
+ */
+export function deriveNameFromWorkspaceId(workspaceId: string): string {
+	const first = workspaceId.split("-")[0] || workspaceId;
+	return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+/**
+ * Probe a discovered instance for its first workspace and derive a suggested
+ * name from it. Returns `null` if the instance has no workspaces or the
+ * request fails.
+ */
+export async function suggestNameForInstance(baseUrl: string): Promise<string | null> {
+	try {
+		const res = await httpFetch(`${baseUrl}/v3/workspaces/list?page=1&page_size=1`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+			signal: AbortSignal.timeout(2000),
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { items?: Array<{ id?: string }> };
+		const wsId = data.items?.[0]?.id;
+		if (typeof wsId === "string" && wsId.length > 0) {
+			return deriveNameFromWorkspaceId(wsId);
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkspacesRouteImport } from './routes/workspaces'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ExploreRouteImport } from './routes/explore'
+import { Route as CompareRouteImport } from './routes/compare'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspacesWorkspaceIdRouteImport } from './routes/workspaces_.$workspaceId'
 import { Route as WorkspacesWorkspaceIdWebhooksRouteImport } from './routes/workspaces_.$workspaceId_.webhooks'
@@ -35,6 +36,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ExploreRoute = ExploreRouteImport.update({
   id: '/explore',
   path: '/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompareRoute = CompareRouteImport.update({
+  id: '/compare',
+  path: '/compare',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -92,6 +98,7 @@ const WorkspacesWorkspaceIdPeersPeerIdChatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -121,6 +129,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -137,6 +146,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -151,6 +161,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -165,6 +176,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -180,6 +192,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CompareRoute: typeof CompareRoute
   ExploreRoute: typeof ExploreRoute
   SettingsRoute: typeof SettingsRoute
   WorkspacesRoute: typeof WorkspacesRoute
@@ -214,6 +227,13 @@ declare module '@tanstack/react-router' {
       path: '/explore'
       fullPath: '/explore'
       preLoaderRoute: typeof ExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -284,6 +304,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CompareRoute: CompareRoute,
   ExploreRoute: ExploreRoute,
   SettingsRoute: SettingsRoute,
   WorkspacesRoute: WorkspacesRoute,

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkspacesRouteImport } from './routes/workspaces'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as FleetRouteImport } from './routes/fleet'
 import { Route as ExploreRouteImport } from './routes/explore'
 import { Route as CompareRouteImport } from './routes/compare'
 import { Route as IndexRouteImport } from './routes/index'
@@ -31,6 +32,11 @@ const WorkspacesRoute = WorkspacesRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FleetRoute = FleetRouteImport.update({
+  id: '/fleet',
+  path: '/fleet',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ExploreRoute = ExploreRouteImport.update({
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
+  '/fleet': typeof FleetRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
   '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdRoute
@@ -115,6 +122,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
+  '/fleet': typeof FleetRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
   '/workspaces/$workspaceId': typeof WorkspacesWorkspaceIdRoute
@@ -131,6 +139,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
+  '/fleet': typeof FleetRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
   '/workspaces_/$workspaceId': typeof WorkspacesWorkspaceIdRoute
@@ -148,6 +157,7 @@ export interface FileRouteTypes {
     | '/'
     | '/compare'
     | '/explore'
+    | '/fleet'
     | '/settings'
     | '/workspaces'
     | '/workspaces/$workspaceId'
@@ -163,6 +173,7 @@ export interface FileRouteTypes {
     | '/'
     | '/compare'
     | '/explore'
+    | '/fleet'
     | '/settings'
     | '/workspaces'
     | '/workspaces/$workspaceId'
@@ -178,6 +189,7 @@ export interface FileRouteTypes {
     | '/'
     | '/compare'
     | '/explore'
+    | '/fleet'
     | '/settings'
     | '/workspaces'
     | '/workspaces_/$workspaceId'
@@ -194,6 +206,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CompareRoute: typeof CompareRoute
   ExploreRoute: typeof ExploreRoute
+  FleetRoute: typeof FleetRoute
   SettingsRoute: typeof SettingsRoute
   WorkspacesRoute: typeof WorkspacesRoute
   WorkspacesWorkspaceIdRoute: typeof WorkspacesWorkspaceIdRoute
@@ -220,6 +233,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fleet': {
+      id: '/fleet'
+      path: '/fleet'
+      fullPath: '/fleet'
+      preLoaderRoute: typeof FleetRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/explore': {
@@ -306,6 +326,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CompareRoute: CompareRoute,
   ExploreRoute: ExploreRoute,
+  FleetRoute: FleetRoute,
   SettingsRoute: SettingsRoute,
   WorkspacesRoute: WorkspacesRoute,
   WorkspacesWorkspaceIdRoute: WorkspacesWorkspaceIdRoute,

--- a/packages/web/src/routes/compare.tsx
+++ b/packages/web/src/routes/compare.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompareView } from "@/components/compare/CompareView";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export const Route = createFileRoute("/compare")({
+	validateSearch: (search: Record<string, unknown>): CompareSearch => ({
+		instances: typeof search.instances === "string" ? search.instances : undefined,
+		peer: typeof search.peer === "string" ? search.peer : undefined,
+	}),
+	component: CompareView,
+});

--- a/packages/web/src/routes/fleet.tsx
+++ b/packages/web/src/routes/fleet.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { FleetDashboard } from "@/components/fleet/FleetDashboard";
+
+export const Route = createFileRoute("/fleet")({
+	component: FleetDashboard,
+});

--- a/packages/web/src/test/compare.test.tsx
+++ b/packages/web/src/test/compare.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DemoProvider } from "@/context/DemoContext";
+import { MetadataProvider } from "@/context/MetadataContext";
+import { saveStore } from "@/lib/config";
+import { routeTree } from "@/routeTree.gen";
+
+function renderAt(initialPath: string) {
+	const router = createRouter({
+		routeTree,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+	});
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<DemoProvider>
+				<MetadataProvider>
+					{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+					<RouterProvider router={router as any} />
+				</MetadataProvider>
+			</DemoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("Compare route", () => {
+	it("prompts the user to add instances when none are selected", async () => {
+		saveStore({
+			instances: [
+				{ id: "neo", name: "Neo", baseUrl: "http://localhost:8001", token: "" },
+				{ id: "iris", name: "Iris", baseUrl: "http://localhost:8002", token: "" },
+			],
+			activeId: "neo",
+		});
+		renderAt("/compare");
+		expect(await screen.findByText(/Pick instances to compare/i)).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/test/discovery.test.ts
+++ b/packages/web/src/test/discovery.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { deriveNameFromWorkspaceId } from "@/lib/discovery";
+
+describe("deriveNameFromWorkspaceId", () => {
+	it("capitalizes the prefix before the first hyphen", () => {
+		expect(deriveNameFromWorkspaceId("neo-personal")).toBe("Neo");
+	});
+
+	it("handles a multi-segment workspace id by taking only the first segment", () => {
+		expect(deriveNameFromWorkspaceId("jeeves-codewalnut-work")).toBe("Jeeves");
+	});
+
+	it("falls back to capitalizing the full id when there is no hyphen", () => {
+		expect(deriveNameFromWorkspaceId("standalone")).toBe("Standalone");
+	});
+});

--- a/packages/web/src/test/fleet.test.tsx
+++ b/packages/web/src/test/fleet.test.tsx
@@ -1,0 +1,175 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scopedConclusionsCountOptions, scopedQueueStatusOptions } from "@/api/compareQueries";
+import {
+	computeFleetAggregates,
+	DEFAULT_ROW_METRICS,
+	type FleetRowMetrics,
+} from "@/components/fleet/fleetAggregates";
+import { DemoProvider } from "@/context/DemoContext";
+import { MetadataProvider } from "@/context/MetadataContext";
+import type { Instance } from "@/lib/config";
+import { saveStore } from "@/lib/config";
+import { routeTree } from "@/routeTree.gen";
+
+vi.mock("@/lib/http", () => ({
+	httpFetch: vi.fn(
+		async () =>
+			new Response(JSON.stringify({ items: [], total: 0, page: 1, size: 1, pages: 0 }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+	),
+}));
+
+const neo: Instance = {
+	id: "neo",
+	name: "Neo",
+	baseUrl: "http://localhost:8001",
+	token: "neo-token",
+};
+const iris: Instance = {
+	id: "iris",
+	name: "Iris",
+	baseUrl: "http://localhost:8002",
+	token: "iris-token",
+};
+
+describe("computeFleetAggregates", () => {
+	it("matches snapshot for an empty fleet", () => {
+		expect(computeFleetAggregates([])).toMatchInlineSnapshot(`
+			{
+			  "healthyCount": 0,
+			  "loadingCount": 0,
+			  "totalConclusions": 0,
+			  "totalInstances": 0,
+			  "totalQueueActive": 0,
+			  "totalQueuePending": 0,
+			  "totalWorkspaces": 0,
+			  "unreachableCount": 0,
+			}
+		`);
+	});
+
+	it("matches snapshot for a mixed fleet (healthy, loading, unreachable)", () => {
+		const rows: FleetRowMetrics[] = [
+			{
+				workspaceCount: 3,
+				conclusionCount: 142,
+				queueActive: 2,
+				queuePending: 5,
+				lastSeen: 1_700_000_000_000,
+				health: "ok",
+			},
+			{
+				workspaceCount: 1,
+				conclusionCount: 87,
+				queueActive: 0,
+				queuePending: 0,
+				lastSeen: 1_700_000_001_000,
+				health: "ok",
+			},
+			{ ...DEFAULT_ROW_METRICS },
+			{
+				workspaceCount: 0,
+				conclusionCount: 0,
+				queueActive: 0,
+				queuePending: 0,
+				lastSeen: null,
+				health: "unreachable",
+			},
+		];
+
+		expect(computeFleetAggregates(rows)).toMatchInlineSnapshot(`
+			{
+			  "healthyCount": 2,
+			  "loadingCount": 1,
+			  "totalConclusions": 229,
+			  "totalInstances": 4,
+			  "totalQueueActive": 2,
+			  "totalQueuePending": 5,
+			  "totalWorkspaces": 4,
+			  "unreachableCount": 1,
+			}
+		`);
+	});
+});
+
+describe("scoped option builders", () => {
+	beforeEach(async () => {
+		const { httpFetch } = await import("@/lib/http");
+		(httpFetch as ReturnType<typeof vi.fn>).mockClear();
+	});
+
+	it("scopes queue status requests by instance baseUrl and token", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const opts = scopedQueueStatusOptions(neo, "ws-1");
+		await opts.queryFn();
+		const req = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(req.url).toBe("http://localhost:8001/v3/workspaces/ws-1/queue/status");
+		expect(req.headers.get("Authorization")).toBe("Bearer neo-token");
+	});
+
+	it("scopes conclusions-count requests by instance baseUrl and token", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const opts = scopedConclusionsCountOptions(iris, "ws-9");
+		await opts.queryFn();
+		const req = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(req.url.startsWith("http://localhost:8002/v3/workspaces/ws-9/conclusions/list")).toBe(
+			true,
+		);
+		expect(req.headers.get("Authorization")).toBe("Bearer iris-token");
+	});
+
+	it("produces distinct query keys per instance to prevent cache collisions", () => {
+		const neoKey = scopedQueueStatusOptions(neo, "ws-shared").queryKey;
+		const irisKey = scopedQueueStatusOptions(iris, "ws-shared").queryKey;
+		expect(neoKey).not.toEqual(irisKey);
+		expect(neoKey).toContain("neo");
+		expect(irisKey).toContain("iris");
+	});
+});
+
+function renderRouteAt(initialPath: string) {
+	const router = createRouter({
+		routeTree,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+	});
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<DemoProvider>
+				<MetadataProvider>
+					{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+					<RouterProvider router={router as any} />
+				</MetadataProvider>
+			</DemoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("Fleet route", () => {
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("mounts FleetDashboard at /fleet when an instance is configured", async () => {
+		saveStore({ instances: [neo], activeId: "neo" });
+		renderRouteAt("/fleet");
+		expect(await screen.findByRole("heading", { name: /Fleet/i })).toBeInTheDocument();
+	});
+
+	it("renders one table row per configured instance", async () => {
+		saveStore({ instances: [neo, iris], activeId: "neo" });
+		renderRouteAt("/fleet");
+		const table = await screen.findByRole("table");
+		await waitFor(() => {
+			expect(within(table).getByText("Neo")).toBeInTheDocument();
+			expect(within(table).getByText("Iris")).toBeInTheDocument();
+		});
+		// 1 header + 2 instance rows
+		expect(within(table).getAllByRole("row")).toHaveLength(3);
+	});
+});

--- a/packages/web/src/test/scoped-client.test.ts
+++ b/packages/web/src/test/scoped-client.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { createScopedClient } from "@/api/scopedClient";
+import type { Instance } from "@/lib/config";
+
+vi.mock("@/lib/http", () => ({
+	httpFetch: vi.fn(async () => new Response("{}", { status: 200 })),
+}));
+
+const instance: Instance = {
+	id: "inst-1",
+	name: "Neo",
+	baseUrl: "http://localhost:8001",
+	token: "secret-token",
+};
+
+describe("createScopedClient", () => {
+	it("issues requests to the instance baseUrl", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.url).toBe("http://localhost:8001/v3/keys");
+	});
+
+	it("attaches the instance token as a Bearer Authorization header", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.headers.get("Authorization")).toBe("Bearer secret-token");
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new `/fleet` route that shows a fleet-wide overview across all configured Honcho instances. Built on the Phase 2 scoped-client pattern from the Compare view — each row uses `createScopedClient(instance)` to fetch its own data via the new `useScopedQueueStatus` / `useScopedConclusionsCount` hooks.

The motivation: when running multiple Honcho stacks (e.g. one per agent), `/dashboard` only shows the *active* instance's data because `useWorkspaces()` / `useQueueStatus()` use `client.current`. The Fleet view fans out across every configured instance so you can see the whole fleet at a glance.

### What's in this PR

- **`/fleet` route** mounting a new `FleetDashboard` component.
- **Aggregate metric cards** at the top: Workspaces, Conclusions, Healthy (`N / total`), Unreachable.
- **Per-agent table row** showing: name + hostname, health dot, workspace count, total conclusions, queue (active / pending), last seen.
- **Auto-refresh** of queue status every 10s, matching the existing Dashboard.
- **Sidebar nav** with a `Network` icon, placed between Dashboard and Workspaces.
- **New scoped query hooks + option builders** in `packages/web/src/api/compareQueries.ts` so the row component can use `useQueries` to fan out per-workspace fetches without duplicating query logic.
- **Pure aggregation helper** `computeFleetAggregates` extracted to `fleetAggregates.ts` for testability.

### Architecture notes

- Each `FleetRow` independently fetches its instance's data and reports computed metrics back to `FleetDashboard` via a callback; the parent then computes the aggregates. This keeps query state colocated with the row while still allowing top-level aggregation without a global store.
- React Query keys are scoped by `instance.id` to avoid cross-instance cache collisions (same pattern as the Compare view).
- The conclusions count uses `POST /v3/workspaces/{ws}/conclusions/list` with `size: 1` and reads the `total` field — cheap enough to fan out across N workspaces per instance.

### Out of scope

Charting, time-series, alerting — explicitly deferred. This is the read-only overview.

## Screenshot

Fleet view with 5 configured agents (Honcho stacks unreachable from the dev origin due to CORS, demonstrating the unreachable health state):

<img width="800" alt="Fleet dashboard with 5 agents" src="https://github.com/user-attachments/assets/fleet-dashboard" />

## Test plan

- [x] `pnpm --filter @openconcho/web test` — 7 new tests pass (snapshot aggregation, scoped option builders, route mount, row render). One pre-existing failure in `app.test.tsx` is unrelated.
- [x] `pnpm --filter @openconcho/web typecheck` clean
- [x] `pnpm --filter @openconcho/web lint` clean
- [x] `pnpm --filter @openconcho/web build` builds, fleet chunk is 11kB gzipped to 4kB
- [x] Manual: navigated to `/fleet` with 5 instances configured — table renders one row per instance, aggregate counts correct, sidebar highlights Fleet entry
- [ ] Manual against live Hermes stack: confirm healthy state shows workspace counts + conclusion totals (CORS blocks this from the dev origin, but works in the Tauri desktop build which uses Tauri HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)