### PR TITLE
feat(web): manual dream triggers for benchmarking

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -924,12 +924,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -984,6 +1000,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2268,6 +2285,7 @@ dependencies = [
 name = "openconcho"
 version = "0.8.0"
 dependencies = [
+ "futures",
  "serde",
  "serde_json",
  "tauri",
@@ -2275,6 +2293,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-http",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -17,3 +17,5 @@ tauri-plugin-shell = "2"
 tauri-plugin-deep-link = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["net", "io-util", "time", "rt", "macros"] }
+futures = "0.3"

--- a/packages/desktop/src-tauri/src/discover.rs
+++ b/packages/desktop/src-tauri/src/discover.rs
@@ -1,0 +1,98 @@
+//! Localhost Honcho instance discovery.
+//!
+//! Probes a range of ports on 127.0.0.1 for a Honcho `/health` endpoint
+//! that returns `{"status":"ok"}`. Desktop-only feature: the browser
+//! can't port-scan due to CORS, so this lives in the Tauri Rust shell.
+
+use serde::Serialize;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+const DEFAULT_START_PORT: u16 = 8000;
+const DEFAULT_END_PORT: u16 = 8100;
+const CONNECT_TIMEOUT_MS: u64 = 150;
+const REQUEST_TIMEOUT_MS: u64 = 250;
+
+#[derive(Serialize, Debug)]
+pub struct DiscoveredInstance {
+	pub port: u16,
+	pub base_url: String,
+}
+
+async fn probe_port(port: u16) -> Option<DiscoveredInstance> {
+	let addr = format!("127.0.0.1:{}", port);
+
+	let connect = TcpStream::connect(&addr);
+	let stream = tokio::time::timeout(Duration::from_millis(CONNECT_TIMEOUT_MS), connect)
+		.await
+		.ok()?
+		.ok()?;
+
+	let mut stream = stream;
+	let req = b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+
+	let io = async {
+		stream.write_all(req).await.ok()?;
+		let mut buf = Vec::with_capacity(512);
+		stream.read_to_end(&mut buf).await.ok()?;
+		Some(buf)
+	};
+	let buf = tokio::time::timeout(Duration::from_millis(REQUEST_TIMEOUT_MS), io)
+		.await
+		.ok()??;
+
+	let body = String::from_utf8_lossy(&buf);
+	if body.contains("\"status\":\"ok\"") {
+		Some(DiscoveredInstance {
+			port,
+			base_url: format!("http://127.0.0.1:{}", port),
+		})
+	} else {
+		None
+	}
+}
+
+#[tauri::command]
+pub async fn discover_honcho_instances(
+	start_port: Option<u16>,
+	end_port: Option<u16>,
+) -> Vec<DiscoveredInstance> {
+	let start = start_port.unwrap_or(DEFAULT_START_PORT);
+	let end = end_port.unwrap_or(DEFAULT_END_PORT);
+	if end < start {
+		return Vec::new();
+	}
+
+	let probes: Vec<_> = (start..=end).map(probe_port).collect();
+	let results = futures::future::join_all(probes).await;
+	let mut found: Vec<DiscoveredInstance> = results.into_iter().flatten().collect();
+	found.sort_by_key(|d| d.port);
+	found
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn rejects_inverted_port_range() {
+		let found = discover_honcho_instances(Some(9000), Some(8000)).await;
+		assert!(found.is_empty());
+	}
+
+	#[tokio::test]
+	async fn ignores_ports_with_no_listener() {
+		// Port 1 should reliably have no listener — connect fails fast.
+		let result = probe_port(1).await;
+		assert!(result.is_none());
+	}
+
+	#[tokio::test]
+	#[ignore = "requires live Honcho stacks on 8001-8005"]
+	async fn finds_live_hermes_stacks() {
+		let found = discover_honcho_instances(Some(8000), Some(8010)).await;
+		let ports: Vec<u16> = found.iter().map(|d| d.port).collect();
+		assert_eq!(ports, vec![8001, 8002, 8003, 8004, 8005]);
+	}
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,12 @@
+mod discover;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_deep_link::init())
+        .invoke_handler(tauri::generate_handler![discover::discover_honcho_instances])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/packages/web/src/api/compareQueries.ts
+++ b/packages/web/src/api/compareQueries.ts
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Instance } from "@/lib/config";
+import { createScopedClient } from "./scopedClient";
+
+function err(e: unknown): never {
+	throw new Error(typeof e === "object" ? JSON.stringify(e) : String(e));
+}
+
+// Query keys are scoped by instance.id so caches never collide across columns.
+const CK = {
+	workspaces: (instId: string, page: number, size: number) =>
+		["compare", instId, "workspaces", page, size] as const,
+	peers: (instId: string, wsId: string, page: number, size: number) =>
+		["compare", instId, "peers", wsId, page, size] as const,
+	peerRepresentation: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-representation", wsId, pId] as const,
+	peerCard: (instId: string, wsId: string, pId: string) =>
+		["compare", instId, "peer-card", wsId, pId] as const,
+};
+
+export function useScopedWorkspaces(instance: Instance, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.workspaces(instance.id, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/list", {
+				params: { query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+	});
+}
+
+export function useScopedPeers(instance: Instance, workspaceId: string, page = 1, pageSize = 20) {
+	return useQuery({
+		queryKey: CK.peers(instance.id, workspaceId, page, pageSize),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST("/v3/workspaces/{workspace_id}/peers/list", {
+				params: { path: { workspace_id: workspaceId }, query: { page, page_size: pageSize } },
+				body: {},
+			});
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId),
+	});
+}
+
+export function useScopedPeerRepresentation(
+	instance: Instance,
+	workspaceId: string,
+	peerId: string,
+) {
+	return useQuery({
+		queryKey: CK.peerRepresentation(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.POST(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/representation",
+				{
+					params: { path: { workspace_id: workspaceId, peer_id: peerId } },
+					body: { max_conclusions: 20 },
+				},
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}
+
+export function useScopedPeerCard(instance: Instance, workspaceId: string, peerId: string) {
+	return useQuery({
+		queryKey: CK.peerCard(instance.id, workspaceId, peerId),
+		queryFn: async () => {
+			const client = createScopedClient(instance);
+			const { data, error } = await client.GET(
+				"/v3/workspaces/{workspace_id}/peers/{peer_id}/card",
+				{ params: { path: { workspace_id: workspaceId, peer_id: peerId } } },
+			);
+			return data ?? err(error);
+		},
+		enabled: Boolean(workspaceId) && Boolean(peerId),
+	});
+}

--- a/packages/web/src/api/scopedClient.ts
+++ b/packages/web/src/api/scopedClient.ts
@@ -1,0 +1,18 @@
+import createClient from "openapi-fetch";
+import type { Instance } from "@/lib/config";
+import { httpFetch } from "@/lib/http";
+import type { paths } from "./schema.d.ts";
+
+export type ScopedClient = ReturnType<typeof createClient<paths>>;
+
+/**
+ * Create an openapi-fetch client bound to a specific instance. Use for views
+ * that need to query non-active instances (e.g. side-by-side comparison).
+ * For single-instance access, prefer `client.current` which tracks the active
+ * instance via localStorage.
+ */
+export function createScopedClient(instance: Instance): ScopedClient {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (instance.token) headers.Authorization = `Bearer ${instance.token}`;
+	return createClient<paths>({ baseUrl: instance.baseUrl, headers, fetch: httpFetch });
+}

--- a/packages/web/src/components/compare/CompareColumn.tsx
+++ b/packages/web/src/components/compare/CompareColumn.tsx
@@ -1,0 +1,210 @@
+import { X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	useScopedPeerCard,
+	useScopedPeerRepresentation,
+	useScopedPeers,
+	useScopedWorkspaces,
+} from "@/api/compareQueries";
+import type { components } from "@/api/schema.d.ts";
+import { ErrorAlert } from "@/components/shared/ErrorAlert";
+import { PeerCardViewer } from "@/components/shared/PeerCardViewer";
+import { Skeleton } from "@/components/shared/Skeleton";
+import { Caption, MonoCaption, SectionHeading } from "@/components/ui/typography";
+import { useDemo } from "@/hooks/useDemo";
+import type { Instance } from "@/lib/config";
+
+type Workspace = components["schemas"]["Workspace"];
+type Peer = components["schemas"]["Peer"];
+type Conclusion = components["schemas"]["Conclusion"];
+
+interface Props {
+	instance: Instance;
+	targetPeerName: string | undefined;
+	onRemove: () => void;
+}
+
+export function CompareColumn({ instance, targetPeerName, onRemove }: Props) {
+	const { mask } = useDemo();
+	const [workspaceId, setWorkspaceId] = useState<string>("");
+	const [peerId, setPeerId] = useState<string>("");
+
+	const workspacesQuery = useScopedWorkspaces(instance);
+	const peersQuery = useScopedPeers(instance, workspaceId);
+	const representation = useScopedPeerRepresentation(instance, workspaceId, peerId);
+	const card = useScopedPeerCard(instance, workspaceId, peerId);
+
+	const workspaces: Workspace[] = useMemo(
+		() => (workspacesQuery.data as { items?: Workspace[] } | undefined)?.items ?? [],
+		[workspacesQuery.data],
+	);
+	const peers: Peer[] = useMemo(
+		() => (peersQuery.data as { items?: Peer[] } | undefined)?.items ?? [],
+		[peersQuery.data],
+	);
+
+	// Auto-select first workspace once loaded.
+	useEffect(() => {
+		if (workspaces.length > 0 && !workspaceId) {
+			setWorkspaceId(workspaces[0].id);
+		}
+	}, [workspaces, workspaceId]);
+
+	// Auto-select peer: prefer the target name if it exists in this instance,
+	// otherwise fall back to the first peer.
+	useEffect(() => {
+		if (peers.length === 0) return;
+		if (targetPeerName) {
+			const match = peers.find((p) => p.id === targetPeerName);
+			if (match && match.id !== peerId) {
+				setPeerId(match.id);
+				return;
+			}
+			if (match) return;
+		}
+		if (!peerId) setPeerId(peers[0].id);
+	}, [peers, targetPeerName, peerId]);
+
+	const cardLines: string[] = useMemo(() => {
+		const raw = (card.data as { peer_card?: unknown } | undefined)?.peer_card;
+		if (Array.isArray(raw)) return raw as string[];
+		if (typeof raw === "string") return [raw];
+		return [];
+	}, [card.data]);
+
+	const conclusions: Conclusion[] = useMemo(() => {
+		const raw = (representation.data as { conclusions?: Conclusion[] } | undefined)?.conclusions;
+		return Array.isArray(raw) ? raw : [];
+	}, [representation.data]);
+
+	return (
+		<div
+			className="flex flex-col h-full rounded-lg overflow-hidden min-w-0"
+			style={{ background: "var(--surface)", border: "1px solid var(--border)" }}
+		>
+			<header
+				className="px-4 py-3 flex items-center justify-between gap-2"
+				style={{ borderBottom: "1px solid var(--border)", background: "var(--bg-2)" }}
+			>
+				<div className="min-w-0 flex-1">
+					<p
+						className="text-sm font-medium truncate"
+						style={{ color: "var(--text-1)" }}
+						title={instance.name}
+					>
+						{instance.name}
+					</p>
+					<MonoCaption as="p" className="truncate" title={mask(instance.baseUrl)}>
+						{mask(instance.baseUrl.replace(/^https?:\/\//, ""))}
+					</MonoCaption>
+				</div>
+				<button
+					type="button"
+					onClick={onRemove}
+					className="w-7 h-7 rounded-md flex items-center justify-center transition-colors shrink-0 hover:opacity-80"
+					style={{ color: "var(--text-3)", background: "transparent" }}
+					title="Remove from compare"
+					aria-label={`Remove ${instance.name} from comparison`}
+				>
+					<X className="w-4 h-4" strokeWidth={1.5} />
+				</button>
+			</header>
+
+			<div className="px-4 py-3 space-y-2" style={{ borderBottom: "1px solid var(--border)" }}>
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Workspace
+					<select
+						value={workspaceId}
+						onChange={(e) => {
+							setWorkspaceId(e.target.value);
+							setPeerId("");
+						}}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+					>
+						{workspacesQuery.isLoading && <option>Loading…</option>}
+						{!workspacesQuery.isLoading && workspaces.length === 0 && (
+							<option value="">No workspaces</option>
+						)}
+						{workspaces.map((ws) => (
+							<option key={ws.id} value={ws.id}>
+								{mask(ws.id)}
+							</option>
+						))}
+					</select>
+				</label>
+
+				<label className="block text-xs font-medium" style={{ color: "var(--text-3)" }}>
+					Peer
+					<select
+						value={peerId}
+						onChange={(e) => setPeerId(e.target.value)}
+						className="mt-1 w-full px-2 py-1.5 text-sm rounded-md font-mono"
+						style={{
+							background: "var(--bg-2)",
+							border: "1px solid var(--border)",
+							color: "var(--text-2)",
+						}}
+						disabled={!workspaceId}
+					>
+						{peersQuery.isLoading && <option>Loading…</option>}
+						{!peersQuery.isLoading && peers.length === 0 && <option value="">No peers</option>}
+						{peers.map((p) => (
+							<option key={p.id} value={p.id}>
+								{mask(p.id)}
+							</option>
+						))}
+					</select>
+				</label>
+			</div>
+
+			<div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+				{workspacesQuery.error && <ErrorAlert error={workspacesQuery.error} />}
+
+				{peerId && (
+					<>
+						<section>
+							<SectionHeading className="mb-2">Conclusions</SectionHeading>
+							{representation.isLoading && <Skeleton className="h-24" />}
+							{!representation.isLoading && conclusions.length === 0 && (
+								<Caption>No conclusions yet for this peer.</Caption>
+							)}
+							{conclusions.length > 0 && (
+								<ul className="space-y-1.5">
+									{conclusions.map((c, i) => (
+										<li
+											key={`${i}-${c.content.slice(0, 32)}`}
+											className="text-sm leading-relaxed px-3 py-2 rounded-md break-words"
+											style={{
+												background: "var(--bg-2)",
+												border: "1px solid var(--border)",
+												color: "var(--text-2)",
+											}}
+										>
+											{c.content}
+										</li>
+									))}
+								</ul>
+							)}
+							{conclusions.length > 0 && (
+								<Caption className="mt-2 block">
+									{conclusions.length} {conclusions.length === 1 ? "conclusion" : "conclusions"}
+								</Caption>
+							)}
+						</section>
+
+						<section>
+							<SectionHeading className="mb-2">Peer card</SectionHeading>
+							{card.isLoading && <Skeleton className="h-32" />}
+							{!card.isLoading && <PeerCardViewer lines={cardLines} />}
+						</section>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/compare/CompareView.tsx
+++ b/packages/web/src/components/compare/CompareView.tsx
@@ -1,0 +1,192 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Columns2, Plus } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Body, Caption, PageTitle } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import type { Instance } from "@/lib/config";
+import { CompareColumn } from "./CompareColumn";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export function CompareView() {
+	const navigate = useNavigate();
+	const search = useSearch({ strict: false }) as CompareSearch;
+	const { instances } = useInstances();
+
+	const selectedIds = useMemo(() => {
+		if (!search.instances) return [];
+		return search.instances.split(",").filter(Boolean);
+	}, [search.instances]);
+
+	const selected: Instance[] = useMemo(() => {
+		const lookup = new Map(instances.map((i) => [i.id, i] as const));
+		return selectedIds.map((id) => lookup.get(id)).filter((i): i is Instance => i !== undefined);
+	}, [selectedIds, instances]);
+
+	const available = useMemo(
+		() => instances.filter((i) => !selectedIds.includes(i.id)),
+		[instances, selectedIds],
+	);
+
+	const [pickerOpen, setPickerOpen] = useState(false);
+	const pickerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!pickerOpen) return;
+		function onClick(e: MouseEvent) {
+			if (!pickerRef.current?.contains(e.target as Node)) setPickerOpen(false);
+		}
+		window.addEventListener("mousedown", onClick);
+		return () => window.removeEventListener("mousedown", onClick);
+	}, [pickerOpen]);
+
+	function setInstancesSearch(ids: string[]) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, instances: ids.length > 0 ? ids.join(",") : undefined } as never,
+		});
+	}
+
+	function addInstance(id: string) {
+		setInstancesSearch([...selectedIds, id]);
+		setPickerOpen(false);
+	}
+
+	function removeInstance(id: string) {
+		setInstancesSearch(selectedIds.filter((sid) => sid !== id));
+	}
+
+	function setTargetPeer(peer: string) {
+		navigate({
+			to: "/compare" as never,
+			search: { ...search, peer: peer || undefined } as never,
+		});
+	}
+
+	if (instances.length === 0) {
+		return (
+			<div className="page-container">
+				<PageTitle>Compare</PageTitle>
+				<Body className="mt-2">
+					Configure at least two Honcho instances in Settings before using compare.
+				</Body>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col h-full">
+			<div
+				className="px-6 py-4 flex items-start justify-between gap-4 flex-wrap"
+				style={{ borderBottom: "1px solid var(--border)" }}
+			>
+				<div>
+					<PageTitle>Compare</PageTitle>
+					<Caption as="p" className="mt-0.5">
+						Side-by-side view of peer representations across instances
+					</Caption>
+				</div>
+				<div className="flex items-center gap-3 flex-wrap">
+					<label
+						className="text-xs font-medium flex items-center gap-2"
+						style={{ color: "var(--text-3)" }}
+					>
+						Target peer
+						<input
+							type="text"
+							value={search.peer ?? ""}
+							onChange={(e) => setTargetPeer(e.target.value)}
+							placeholder="ben"
+							className="px-2 py-1 text-sm rounded-md font-mono"
+							style={{
+								background: "var(--bg-2)",
+								border: "1px solid var(--border)",
+								color: "var(--text-2)",
+								width: "12rem",
+							}}
+						/>
+					</label>
+
+					<div ref={pickerRef} className="relative">
+						<button
+							type="button"
+							onClick={() => setPickerOpen((v) => !v)}
+							disabled={available.length === 0}
+							className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors"
+							style={{
+								background: "var(--accent-dim)",
+								border: "1px solid var(--accent-border)",
+								color: "var(--accent-text)",
+								opacity: available.length === 0 ? 0.5 : 1,
+								cursor: available.length === 0 ? "not-allowed" : "pointer",
+							}}
+						>
+							<Plus className="w-4 h-4" strokeWidth={2} />
+							Add instance
+						</button>
+						{pickerOpen && available.length > 0 && (
+							<div
+								className="absolute right-0 top-full mt-1 rounded-lg overflow-hidden z-20 min-w-[14rem]"
+								style={{
+									background: "var(--bg-2)",
+									border: "1px solid var(--border)",
+									boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+								}}
+							>
+								{available.map((inst) => (
+									<button
+										key={inst.id}
+										type="button"
+										onClick={() => addInstance(inst.id)}
+										className="w-full flex flex-col items-start px-3 py-2 text-left transition-colors hover:opacity-80"
+										style={{ background: "transparent" }}
+									>
+										<span className="text-sm font-medium" style={{ color: "var(--text-2)" }}>
+											{inst.name}
+										</span>
+										<span
+											className="text-xs font-mono truncate w-full"
+											style={{ color: "var(--text-4)" }}
+										>
+											{inst.baseUrl.replace(/^https?:\/\//, "")}
+										</span>
+									</button>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{selected.length === 0 ? (
+				<div className="flex-1 flex items-center justify-center">
+					<EmptyState
+						icon={Columns2}
+						title="Pick instances to compare"
+						description="Add two or more configured Honcho instances to see their peer representations side by side."
+					/>
+				</div>
+			) : (
+				<div
+					className="flex-1 grid gap-3 px-6 py-4 overflow-x-auto"
+					style={{
+						gridTemplateColumns: `repeat(${selected.length}, minmax(20rem, 1fr))`,
+					}}
+				>
+					{selected.map((inst) => (
+						<CompareColumn
+							key={inst.id}
+							instance={inst}
+							targetPeerName={search.peer || undefined}
+							onRemove={() => removeInstance(inst.id)}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/fleet/FleetDreamDialog.tsx
+++ b/packages/web/src/components/fleet/FleetDreamDialog.tsx
@@ -1,0 +1,306 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { AlertCircle, CheckCircle2, Loader2, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FormModal } from "@/components/shared/FormModal";
+import { Button } from "@/components/ui/button";
+import { Caption } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import type { Instance } from "@/lib/config";
+import {
+	type FleetDreamStepResult,
+	type FleetInstanceSummary,
+	fanOutDreams,
+	planFleetTargets,
+	summarizeByInstance,
+} from "@/lib/fleetDream";
+import { toast } from "@/lib/toast";
+
+type Phase = "idle" | "planning" | "running" | "done";
+
+interface Props {
+	open: boolean;
+	onClose: () => void;
+}
+
+export function FleetDreamDialog({ open, onClose }: Props) {
+	const { instances } = useInstances();
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [planError, setPlanError] = useState<string | null>(null);
+	const [perInstanceErrors, setPerInstanceErrors] = useState<Array<{ name: string; msg: string }>>(
+		[],
+	);
+	const [summary, setSummary] = useState<Map<string, FleetInstanceSummary>>(new Map());
+	const [totalTargets, setTotalTargets] = useState(0);
+	const [completed, setCompleted] = useState(0);
+	const cancelled = useRef(false);
+
+	const reset = useCallback(() => {
+		setPhase("idle");
+		setPlanError(null);
+		setPerInstanceErrors([]);
+		setSummary(new Map());
+		setTotalTargets(0);
+		setCompleted(0);
+	}, []);
+
+	useEffect(() => {
+		if (!open) reset();
+	}, [open, reset]);
+
+	const handleRun = async () => {
+		cancelled.current = false;
+		reset();
+		setPhase("planning");
+		const errors: Array<{ name: string; msg: string }> = [];
+		const targets = await planFleetTargets(instances, {
+			onInstanceError: (inst, err) => errors.push({ name: inst.name, msg: err.message }),
+		});
+		if (cancelled.current) return;
+		setPerInstanceErrors(errors);
+		if (targets.length === 0) {
+			setPlanError(
+				errors.length > 0
+					? "No targets found — every instance failed to list workspaces or peers."
+					: "No workspaces or peers found on any configured instance.",
+			);
+			setPhase("done");
+			return;
+		}
+
+		setTotalTargets(targets.length);
+		setPhase("running");
+
+		const liveResults: FleetDreamStepResult[] = [];
+		await fanOutDreams(targets, {
+			onProgress: (result) => {
+				if (cancelled.current) return;
+				if (result.status === "success" || result.status === "error") {
+					liveResults.push(result);
+					setCompleted(liveResults.length);
+					setSummary(summarizeByInstance(liveResults));
+				}
+			},
+		});
+
+		if (cancelled.current) return;
+		const finalSummary = summarizeByInstance(liveResults);
+		const totalOk = liveResults.filter((r) => r.status === "success").length;
+		const totalFail = liveResults.length - totalOk;
+		setSummary(finalSummary);
+		setPhase("done");
+		if (totalFail === 0) {
+			toast(`Queued ${totalOk} dreams across ${finalSummary.size} instance(s)`, {
+				kind: "success",
+			});
+		} else {
+			toast(`Dreamed ${totalOk}, ${totalFail} failed — see dialog`, { kind: "error" });
+		}
+	};
+
+	const handleClose = () => {
+		cancelled.current = true;
+		onClose();
+	};
+
+	const isBusy = phase === "planning" || phase === "running";
+
+	return (
+		<FormModal open={open} title="Dream the fleet" onClose={handleClose} maxWidth="max-w-lg">
+			<div className="space-y-4">
+				<Caption as="p">
+					Fires <code className="font-mono">schedule_dream</code> for every peer in every workspace
+					on every configured instance. Useful for kicking benchmarks without waiting for the cron.
+				</Caption>
+
+				{instances.length === 0 ? (
+					<div
+						className="rounded-lg p-3 text-xs"
+						style={{
+							background: "rgba(245,158,11,0.08)",
+							border: "1px solid rgba(245,158,11,0.2)",
+							color: "var(--text-2)",
+						}}
+					>
+						No instances configured. Add one in Settings before dreaming the fleet.
+					</div>
+				) : (
+					<InstancesList instances={instances} summary={summary} phase={phase} />
+				)}
+
+				{phase === "running" && totalTargets > 0 && (
+					<ProgressBar completed={completed} total={totalTargets} />
+				)}
+
+				{planError && (
+					<div className="rounded-lg p-3 text-xs" style={{ color: "#f87171" }}>
+						{planError}
+					</div>
+				)}
+
+				{perInstanceErrors.length > 0 && (
+					<div
+						className="rounded-lg p-3 text-xs space-y-1"
+						style={{
+							background: "rgba(239,68,68,0.06)",
+							border: "1px solid rgba(239,68,68,0.2)",
+						}}
+					>
+						<div className="font-medium" style={{ color: "#f87171" }}>
+							Instance listing errors
+						</div>
+						{perInstanceErrors.map((e) => (
+							<div key={e.name} className="font-mono" style={{ color: "var(--text-3)" }}>
+								<span style={{ color: "var(--text-2)" }}>{e.name}:</span> {e.msg}
+							</div>
+						))}
+					</div>
+				)}
+
+				<div className="flex justify-end gap-2 pt-2">
+					<Button type="button" variant="surface" size="sm" onClick={handleClose}>
+						{phase === "done" ? "Close" : "Cancel"}
+					</Button>
+					<Button
+						type="button"
+						variant="accent"
+						size="sm"
+						onClick={handleRun}
+						disabled={isBusy || instances.length === 0}
+					>
+						{phase === "planning"
+							? "Planning..."
+							: phase === "running"
+								? `Dreaming ${completed}/${totalTargets}...`
+								: phase === "done"
+									? "Run again"
+									: "Dream fleet"}
+					</Button>
+				</div>
+			</div>
+		</FormModal>
+	);
+}
+
+function ProgressBar({ completed, total }: { completed: number; total: number }) {
+	const pct = total === 0 ? 0 : Math.round((completed / total) * 100);
+	return (
+		<div className="space-y-1">
+			<div className="flex justify-between text-xs" style={{ color: "var(--text-3)" }}>
+				<span>Progress</span>
+				<span className="font-mono">
+					{completed} / {total}
+				</span>
+			</div>
+			<div className="h-1.5 rounded-full overflow-hidden" style={{ background: "var(--surface)" }}>
+				<motion.div
+					className="h-full"
+					style={{ background: "var(--accent)" }}
+					initial={{ width: 0 }}
+					animate={{ width: `${pct}%` }}
+					transition={{ duration: 0.25 }}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function InstancesList({
+	instances,
+	summary,
+	phase,
+}: {
+	instances: Instance[];
+	summary: Map<string, FleetInstanceSummary>;
+	phase: Phase;
+}) {
+	return (
+		<div className="rounded-lg overflow-hidden" style={{ border: "1px solid var(--border)" }}>
+			{instances.map((inst, i) => {
+				const s = summary.get(inst.id);
+				return (
+					<div
+						key={inst.id}
+						className="flex items-center gap-3 px-3 py-2.5"
+						style={{
+							borderTop: i > 0 ? "1px solid var(--border)" : undefined,
+							background: "var(--bg-2)",
+						}}
+					>
+						<InstanceStatusIcon instanceId={inst.id} summary={s} phase={phase} />
+						<div className="flex-1 min-w-0">
+							<div className="text-sm font-medium truncate" style={{ color: "var(--text-1)" }}>
+								{inst.name}
+							</div>
+							<div className="text-xs font-mono truncate" style={{ color: "var(--text-4)" }}>
+								{inst.baseUrl.replace(/^https?:\/\//, "")}
+							</div>
+						</div>
+						<InstanceCounts summary={s} phase={phase} />
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function InstanceStatusIcon({
+	instanceId,
+	summary,
+	phase,
+}: {
+	instanceId: string;
+	summary: FleetInstanceSummary | undefined;
+	phase: Phase;
+}) {
+	if (phase === "idle" || phase === "planning") {
+		return <Sparkles className="w-4 h-4 shrink-0" style={{ color: "var(--text-4)" }} />;
+	}
+	if (!summary) {
+		return <Loader2 className="w-4 h-4 shrink-0 animate-spin" style={{ color: "var(--text-4)" }} />;
+	}
+	if (summary.failed > 0) {
+		return (
+			<AlertCircle key={instanceId} className="w-4 h-4 shrink-0" style={{ color: "#f87171" }} />
+		);
+	}
+	return (
+		<AnimatePresence mode="wait">
+			<motion.div
+				key={summary.total}
+				initial={{ scale: 0.6, opacity: 0 }}
+				animate={{ scale: 1, opacity: 1 }}
+			>
+				<CheckCircle2 className="w-4 h-4 shrink-0" style={{ color: "#34d399" }} />
+			</motion.div>
+		</AnimatePresence>
+	);
+}
+
+function InstanceCounts({
+	summary,
+	phase,
+}: {
+	summary: FleetInstanceSummary | undefined;
+	phase: Phase;
+}) {
+	if (phase === "idle" || phase === "planning") return null;
+	if (!summary) {
+		return (
+			<span className="text-xs font-mono" style={{ color: "var(--text-4)" }}>
+				waiting…
+			</span>
+		);
+	}
+	return (
+		<span className="text-xs font-mono whitespace-nowrap" style={{ color: "var(--text-3)" }}>
+			<span style={{ color: "#34d399" }}>{summary.success}</span>
+			{summary.failed > 0 && (
+				<>
+					<span> / </span>
+					<span style={{ color: "#f87171" }}>{summary.failed} failed</span>
+				</>
+			)}
+			<span style={{ color: "var(--text-4)" }}> / {summary.total}</span>
+		</span>
+	);
+}

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
 	Check,
 	ChevronRight,
 	ChevronsUpDown,
+	Columns2,
 	Eye,
 	EyeOff,
 	LayoutDashboard,
@@ -29,6 +30,7 @@ import { COLOR } from "@/lib/constants";
 const TOP_NAV = [
 	{ to: "/" as const, label: "Dashboard", icon: LayoutDashboard, exact: true },
 	{ to: "/workspaces" as const, label: "Workspaces", icon: Boxes, exact: false },
+	{ to: "/compare" as const, label: "Compare", icon: Columns2, exact: false },
 	{ to: "/settings" as const, label: "Settings", icon: Settings, exact: false },
 ];
 

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -14,11 +14,13 @@ import {
 	MessageSquare,
 	Moon,
 	Settings,
+	Sparkles,
 	Sun,
 	Users,
 	Webhook,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { FleetDreamDialog } from "@/components/fleet/FleetDreamDialog";
 import { HealthDot } from "@/components/shared/HealthDot";
 import { useDemo } from "@/hooks/useDemo";
 import { useHealthStatus } from "@/hooks/useHealthStatus";
@@ -49,6 +51,7 @@ export function Sidebar() {
 	const { showMetadata, toggle: toggleMeta } = useMetadata();
 	const { data: health } = useHealthStatus();
 	const [switcherOpen, setSwitcherOpen] = useState(false);
+	const [fleetDreamOpen, setFleetDreamOpen] = useState(false);
 	const switcherRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
@@ -290,11 +293,31 @@ export function Sidebar() {
 				</AnimatePresence>
 			</nav>
 
-			{/* Footer — version, demo, metadata, theme */}
-			<div
-				className="px-3 sm:px-5 py-3 flex items-center justify-between"
-				style={{ borderTop: "1px solid var(--border)" }}
-			>
+			{/* Footer — fleet action, version, demo, metadata, theme */}
+			<div className="px-3 sm:px-5 pt-3" style={{ borderTop: "1px solid var(--border)" }}>
+				<button
+					type="button"
+					onClick={() => setFleetDreamOpen(true)}
+					disabled={instances.length === 0}
+					title={
+						instances.length === 0
+							? "Configure an instance first"
+							: "Trigger dreams across every configured instance"
+					}
+					className="w-full flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors justify-center sm:justify-start"
+					style={{
+						background: "var(--accent-dim)",
+						color: "var(--accent-text)",
+						border: "1px solid var(--accent-border)",
+						opacity: instances.length === 0 ? 0.4 : 1,
+						cursor: instances.length === 0 ? "not-allowed" : "pointer",
+					}}
+				>
+					<Sparkles className="w-3.5 h-3.5 shrink-0" strokeWidth={1.5} />
+					<span className="hidden sm:block">Dream fleet</span>
+				</button>
+			</div>
+			<div className="px-3 sm:px-5 py-3 flex items-center justify-between">
 				<p className="text-xs font-mono hidden sm:block" style={{ color: "var(--text-4)" }}>
 					v{__APP_VERSION__}
 				</p>
@@ -348,6 +371,8 @@ export function Sidebar() {
 					</button>
 				</div>
 			</div>
+
+			<FleetDreamDialog open={fleetDreamOpen} onClose={() => setFleetDreamOpen(false)} />
 		</motion.aside>
 	);
 }

--- a/packages/web/src/components/settings/DiscoveredInstances.tsx
+++ b/packages/web/src/components/settings/DiscoveredInstances.tsx
@@ -1,0 +1,209 @@
+import { motion } from "framer-motion";
+import { Loader, RefreshCw, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Muted } from "@/components/ui/typography";
+import { useInstances } from "@/hooks/useInstances";
+import { COLOR } from "@/lib/constants";
+import {
+	type DiscoveredInstance,
+	discoverHonchoInstances,
+	suggestNameForInstance,
+} from "@/lib/discovery";
+
+interface Row {
+	discovered: DiscoveredInstance;
+	suggestedName: string;
+	checked: boolean;
+}
+
+interface Props {
+	/** If true, scan as soon as the component mounts. */
+	autoRun?: boolean;
+	/** Called after the user has added at least one instance. */
+	onAdded?: () => void;
+}
+
+export function DiscoveredInstances({ autoRun = false, onAdded }: Props) {
+	const { instances, add, activate } = useInstances();
+	const [scanning, setScanning] = useState(false);
+	const [hasScanned, setHasScanned] = useState(false);
+	const [rows, setRows] = useState<Row[]>([]);
+
+	const existingBaseUrls = useMemo(
+		() => new Set(instances.map((i) => i.baseUrl.replace(/\/+$/, "").toLowerCase())),
+		[instances],
+	);
+
+	const runScan = useCallback(async () => {
+		setScanning(true);
+		try {
+			const found = await discoverHonchoInstances();
+			const fresh = found.filter(
+				(d) => !existingBaseUrls.has(d.base_url.replace(/\/+$/, "").toLowerCase()),
+			);
+			const named = await Promise.all(
+				fresh.map(async (d) => {
+					const name = (await suggestNameForInstance(d.base_url)) ?? `Honcho :${d.port}`;
+					return { discovered: d, suggestedName: name, checked: true } satisfies Row;
+				}),
+			);
+			setRows(named);
+		} finally {
+			setScanning(false);
+			setHasScanned(true);
+		}
+	}, [existingBaseUrls]);
+
+	useEffect(() => {
+		if (autoRun) void runScan();
+	}, [autoRun, runScan]);
+
+	function setRowChecked(port: number, checked: boolean) {
+		setRows((r) => r.map((row) => (row.discovered.port === port ? { ...row, checked } : row)));
+	}
+
+	function setRowName(port: number, suggestedName: string) {
+		setRows((r) =>
+			r.map((row) => (row.discovered.port === port ? { ...row, suggestedName } : row)),
+		);
+	}
+
+	function addSelected() {
+		const selected = rows.filter((r) => r.checked);
+		if (selected.length === 0) return;
+		let firstId: string | null = null;
+		for (const row of selected) {
+			const created = add({
+				name: row.suggestedName.trim() || `Honcho :${row.discovered.port}`,
+				baseUrl: row.discovered.base_url,
+				token: "",
+			});
+			if (firstId === null) firstId = created.id;
+		}
+		if (firstId) activate(firstId);
+		setRows([]);
+		onAdded?.();
+	}
+
+	const selectedCount = rows.filter((r) => r.checked).length;
+
+	return (
+		<div
+			className="rounded-2xl p-5 space-y-3"
+			style={{ background: "var(--bg-2)", border: "1px solid var(--border)" }}
+		>
+			<div className="flex items-center justify-between gap-3">
+				<div className="flex items-center gap-2">
+					<Sparkles
+						className="w-4 h-4 shrink-0"
+						style={{ color: COLOR.accentText }}
+						strokeWidth={1.5}
+					/>
+					<div>
+						<p className="text-sm font-medium" style={{ color: "var(--text-1)" }}>
+							Discover local Honcho instances
+						</p>
+						<Muted className="text-xs">Scans 127.0.0.1:8000–8100 for running instances</Muted>
+					</div>
+				</div>
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => void runScan()}
+					disabled={scanning}
+					className="rounded-xl px-3 py-2"
+					title="Rescan"
+				>
+					{scanning ? (
+						<motion.div
+							animate={{ rotate: 360 }}
+							transition={{
+								duration: 1,
+								repeat: Number.POSITIVE_INFINITY,
+								ease: "linear",
+							}}
+						>
+							<Loader className="w-4 h-4" strokeWidth={1.5} />
+						</motion.div>
+					) : (
+						<RefreshCw className="w-4 h-4" strokeWidth={1.5} />
+					)}
+					<span className="hidden sm:inline ml-1.5 text-xs">
+						{scanning ? "Scanning…" : "Rescan"}
+					</span>
+				</Button>
+			</div>
+
+			{hasScanned && !scanning && rows.length === 0 && (
+				<Muted className="text-xs">
+					No new instances found. Add one manually below if you know its URL.
+				</Muted>
+			)}
+
+			{rows.length > 0 && (
+				<>
+					<div className="space-y-1.5">
+						{rows.map((row) => (
+							<DiscoveredRow
+								key={row.discovered.port}
+								row={row}
+								onCheck={(c) => setRowChecked(row.discovered.port, c)}
+								onRename={(n) => setRowName(row.discovered.port, n)}
+							/>
+						))}
+					</div>
+					<Button
+						type="button"
+						variant="accent"
+						onClick={addSelected}
+						disabled={selectedCount === 0}
+						className="w-full rounded-xl py-2.5"
+					>
+						{selectedCount === 0
+							? "Select at least one"
+							: `Add ${selectedCount} instance${selectedCount === 1 ? "" : "s"}`}
+					</Button>
+				</>
+			)}
+		</div>
+	);
+}
+
+interface DiscoveredRowProps {
+	row: Row;
+	onCheck: (checked: boolean) => void;
+	onRename: (name: string) => void;
+}
+
+function DiscoveredRow({ row, onCheck, onRename }: DiscoveredRowProps) {
+	return (
+		<div
+			className="flex items-center gap-2.5 rounded-xl px-3 py-2"
+			style={{
+				background: row.checked ? "var(--surface)" : "transparent",
+				border: `1px solid ${row.checked ? "var(--accent-border)" : "var(--border)"}`,
+			}}
+		>
+			<input
+				type="checkbox"
+				checked={row.checked}
+				onChange={(e) => onCheck(e.target.checked)}
+				className="w-4 h-4 shrink-0 cursor-pointer"
+				aria-label={`Select ${row.suggestedName}`}
+			/>
+			<input
+				type="text"
+				value={row.suggestedName}
+				onChange={(e) => onRename(e.target.value)}
+				className="flex-1 min-w-0 bg-transparent text-sm font-medium border-0 outline-none px-1 py-0.5 rounded"
+				style={{ color: "var(--text-1)" }}
+				aria-label={`Name for instance on port ${row.discovered.port}`}
+				disabled={!row.checked}
+			/>
+			<span className="text-xs font-mono shrink-0" style={{ color: "var(--text-4)" }}>
+				:{row.discovered.port}
+			</span>
+		</div>
+	);
+}

--- a/packages/web/src/components/settings/InstancesManager.tsx
+++ b/packages/web/src/components/settings/InstancesManager.tsx
@@ -1,12 +1,24 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { Check, ChevronRight, Cloud, Pencil, Plus, Server, Sparkles, Trash2 } from "lucide-react";
+import {
+	Check,
+	ChevronRight,
+	Cloud,
+	Pencil,
+	Plus,
+	Radar,
+	Server,
+	Sparkles,
+	Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
+import { DiscoveredInstances } from "@/components/settings/DiscoveredInstances";
 import { type ConnectionPreset, SettingsForm } from "@/components/settings/SettingsForm";
 import { Button } from "@/components/ui/button";
 import { Muted } from "@/components/ui/typography";
 import { useInstances } from "@/hooks/useInstances";
 import { checkConnection, HONCHO_CLOUD_URL, type Instance, isCloudInstance } from "@/lib/config";
 import { COLOR } from "@/lib/constants";
+import { isTauri } from "@/lib/discovery";
 
 const LOCALHOST_PROBE_URL = "http://localhost:8000";
 
@@ -14,7 +26,8 @@ type Mode =
 	| { kind: "list" }
 	| { kind: "choose-type" }
 	| { kind: "create"; preset: ConnectionPreset }
-	| { kind: "edit"; id: string };
+	| { kind: "edit"; id: string }
+	| { kind: "discover" };
 
 interface InstancesManagerProps {
 	onActivated?: () => void;
@@ -23,16 +36,44 @@ interface InstancesManagerProps {
 export function InstancesManager({ onActivated }: InstancesManagerProps) {
 	const { instances, activeId, activate, remove } = useInstances();
 	const isFirstRun = instances.length === 0;
+	const inTauri = isTauri();
 	const [mode, setMode] = useState<Mode>(isFirstRun ? { kind: "choose-type" } : { kind: "list" });
 
 	const backFromCreate = () => setMode(isFirstRun ? { kind: "choose-type" } : { kind: "list" });
 
+	if (mode.kind === "discover") {
+		return (
+			<div className="space-y-3">
+				<DiscoveredInstances autoRun onAdded={() => setMode({ kind: "list" })} />
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => setMode({ kind: "list" })}
+					className="w-full py-2.5 px-4 rounded-xl"
+				>
+					Back
+				</Button>
+			</div>
+		);
+	}
+
 	if (mode.kind === "choose-type") {
 		return (
-			<ConnectionTypeChooser
-				onPick={(preset) => setMode({ kind: "create", preset })}
-				onCancel={isFirstRun ? undefined : () => setMode({ kind: "list" })}
-			/>
+			<div className="space-y-3">
+				{inTauri && (
+					<DiscoveredInstances
+						autoRun
+						onAdded={() => {
+							setMode({ kind: "list" });
+							onActivated?.();
+						}}
+					/>
+				)}
+				<ConnectionTypeChooser
+					onPick={(preset) => setMode({ kind: "create", preset })}
+					onCancel={isFirstRun ? undefined : () => setMode({ kind: "list" })}
+				/>
+			</div>
 		);
 	}
 
@@ -81,6 +122,18 @@ export function InstancesManager({ onActivated }: InstancesManagerProps) {
 					/>
 				))}
 			</div>
+
+			{inTauri && (
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() => setMode({ kind: "discover" })}
+					className="w-full py-2.5 px-4 rounded-xl flex items-center justify-center gap-2"
+				>
+					<Radar className="w-4 h-4" strokeWidth={1.5} />
+					Discover instances
+				</Button>
+			)}
 
 			<Button
 				type="button"

--- a/packages/web/src/components/shared/Toaster.tsx
+++ b/packages/web/src/components/shared/Toaster.tsx
@@ -1,0 +1,82 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { AlertCircle, CheckCircle2, Info, X } from "lucide-react";
+import { useSyncExternalStore } from "react";
+import { dismissToast, getToasts, subscribeToasts, type Toast } from "@/lib/toast";
+
+const ICONS = {
+	success: CheckCircle2,
+	error: AlertCircle,
+	info: Info,
+} as const;
+
+const COLORS: Record<Toast["kind"], { fg: string; bg: string; border: string }> = {
+	success: {
+		fg: "#34d399",
+		bg: "rgba(52,211,153,0.08)",
+		border: "rgba(52,211,153,0.25)",
+	},
+	error: {
+		fg: "#f87171",
+		bg: "rgba(239,68,68,0.08)",
+		border: "rgba(239,68,68,0.25)",
+	},
+	info: {
+		fg: "var(--accent-text)",
+		bg: "var(--accent-dim)",
+		border: "var(--accent-border)",
+	},
+};
+
+export function Toaster() {
+	const toasts = useSyncExternalStore(subscribeToasts, getToasts, getToasts);
+
+	return (
+		<div
+			aria-live="polite"
+			aria-atomic="true"
+			className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none"
+			style={{ maxWidth: "min(22rem, calc(100vw - 2rem))" }}
+		>
+			<AnimatePresence initial={false}>
+				{toasts.map((t) => {
+					const Icon = ICONS[t.kind];
+					const palette = COLORS[t.kind];
+					return (
+						<motion.div
+							key={t.id}
+							layout
+							initial={{ opacity: 0, x: 24, scale: 0.96 }}
+							animate={{ opacity: 1, x: 0, scale: 1 }}
+							exit={{ opacity: 0, x: 24, scale: 0.96 }}
+							transition={{ type: "spring", stiffness: 320, damping: 26 }}
+							className="pointer-events-auto flex items-start gap-2 rounded-xl px-3 py-2.5 shadow-lg"
+							style={{
+								background: palette.bg,
+								border: `1px solid ${palette.border}`,
+								backdropFilter: "blur(8px)",
+							}}
+						>
+							<Icon
+								className="w-4 h-4 mt-0.5 shrink-0"
+								style={{ color: palette.fg }}
+								strokeWidth={2}
+							/>
+							<div className="flex-1 text-xs leading-relaxed" style={{ color: "var(--text-1)" }}>
+								{t.message}
+							</div>
+							<button
+								type="button"
+								onClick={() => dismissToast(t.id)}
+								className="shrink-0 rounded p-0.5 transition-colors"
+								style={{ color: "var(--text-4)" }}
+								aria-label="Dismiss"
+							>
+								<X className="w-3 h-3" strokeWidth={2} />
+							</button>
+						</motion.div>
+					);
+				})}
+			</AnimatePresence>
+		</div>
+	);
+}

--- a/packages/web/src/components/workspaces/ScheduleDreamModal.tsx
+++ b/packages/web/src/components/workspaces/ScheduleDreamModal.tsx
@@ -1,12 +1,16 @@
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useState } from "react";
 import { z } from "zod";
+import { usePeers } from "@/api/queries";
 import { FormModal } from "@/components/shared/FormModal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Caption } from "@/components/ui/typography";
 import { COLOR } from "@/lib/constants";
+import { toast } from "@/lib/toast";
+
+const PEER_PAGE_SIZE = 100;
 
 const schema = z.object({
 	observer: z.string().min(1, { message: "Observer peer ID is required" }),
@@ -25,7 +29,10 @@ interface Props {
 	>;
 }
 
-export function ScheduleDreamModal({ open, onClose, mutation }: Props) {
+export function ScheduleDreamModal({ open, workspaceId, onClose, mutation }: Props) {
+	const { data: peerPage } = usePeers(workspaceId, 1, PEER_PAGE_SIZE);
+	const peers = (peerPage as { items?: Array<{ id: string }> } | undefined)?.items ?? [];
+
 	const [observer, setObserver] = useState("");
 	const [observed, setObserved] = useState("");
 	const [sessionId, setSessionId] = useState("");
@@ -49,12 +56,15 @@ export function ScheduleDreamModal({ open, onClose, mutation }: Props) {
 			setValidationError(result.error.issues[0].message);
 			return;
 		}
+		// Default observed → observer for self-representation dreams.
+		const observedId = result.data.observed ?? result.data.observer;
 		await mutation.mutateAsync({
 			observer: result.data.observer,
-			observed: result.data.observed ?? null,
+			observed: observedId,
 			dream_type: "omni",
 			session_id: result.data.session_id ?? null,
 		});
+		toast(`Dream queued for ${result.data.observer}`, { kind: "success" });
 		reset();
 		onClose();
 	};
@@ -62,7 +72,7 @@ export function ScheduleDreamModal({ open, onClose, mutation }: Props) {
 	return (
 		<FormModal
 			open={open}
-			title="Schedule Dream"
+			title="Dream now"
 			onClose={() => {
 				reset();
 				onClose();
@@ -71,25 +81,27 @@ export function ScheduleDreamModal({ open, onClose, mutation }: Props) {
 			<form onSubmit={handleSubmit} className="space-y-4">
 				<div>
 					<Label className="mb-1.5">
-						Observer peer ID <span style={{ color: COLOR.destructive }}>*</span>
+						Observer peer <span style={{ color: COLOR.destructive }}>*</span>
 					</Label>
-					<Input
+					<PeerPicker
 						value={observer}
-						onChange={(e) => {
-							setObserver(e.target.value);
+						onChange={(v) => {
+							setObserver(v);
 							setValidationError("");
 						}}
+						peers={peers}
 						placeholder="peer_id"
 					/>
 				</div>
 				<div>
 					<Label className="mb-1.5">
-						Observed peer ID <Caption as="span"> (optional, defaults to observer)</Caption>
+						Observed peer <Caption as="span"> (optional, defaults to observer)</Caption>
 					</Label>
-					<Input
+					<PeerPicker
 						value={observed}
-						onChange={(e) => setObserved(e.target.value)}
-						placeholder="peer_id"
+						onChange={setObserved}
+						peers={peers}
+						placeholder={observer ? observer : "peer_id"}
 					/>
 				</div>
 				<div>
@@ -125,10 +137,46 @@ export function ScheduleDreamModal({ open, onClose, mutation }: Props) {
 						Cancel
 					</Button>
 					<Button type="submit" variant="accent" size="sm" disabled={mutation.isPending}>
-						{mutation.isPending ? "Scheduling..." : "Schedule"}
+						{mutation.isPending ? "Scheduling..." : "Dream now"}
 					</Button>
 				</div>
 			</form>
 		</FormModal>
 	);
+}
+
+interface PeerPickerProps {
+	value: string;
+	onChange: (value: string) => void;
+	peers: Array<{ id: string }>;
+	placeholder?: string;
+}
+
+function PeerPicker({ value, onChange, peers, placeholder }: PeerPickerProps) {
+	const hasPeers = peers.length > 0;
+	const listId = useRandomId("peer-list");
+	return (
+		<>
+			<Input
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				list={hasPeers ? listId : undefined}
+				className="font-mono"
+				autoComplete="off"
+			/>
+			{hasPeers && (
+				<datalist id={listId}>
+					{peers.map((p) => (
+						<option key={p.id} value={p.id} />
+					))}
+				</datalist>
+			)}
+		</>
+	);
+}
+
+function useRandomId(prefix: string): string {
+	const [id] = useState(() => `${prefix}-${Math.random().toString(36).slice(2, 10)}`);
+	return id;
 }

--- a/packages/web/src/components/workspaces/WorkspaceDetail.tsx
+++ b/packages/web/src/components/workspaces/WorkspaceDetail.tsx
@@ -89,7 +89,7 @@ export function WorkspaceDetail() {
 					<div className="flex items-center gap-2 flex-shrink-0">
 						<Button variant="accent" size="sm" onClick={() => setDreamOpen(true)}>
 							<Zap className="w-3.5 h-3.5" strokeWidth={2} />
-							Schedule Dream
+							Dream now
 						</Button>
 						<Button variant="destructive" size="sm" onClick={() => setConfirmDelete(true)}>
 							<Trash2 className="w-3.5 h-3.5" strokeWidth={2} />

--- a/packages/web/src/lib/discovery.ts
+++ b/packages/web/src/lib/discovery.ts
@@ -1,0 +1,57 @@
+import { httpFetch } from "@/lib/http";
+
+export interface DiscoveredInstance {
+	port: number;
+	base_url: string;
+}
+
+export function isTauri(): boolean {
+	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Probe localhost ports for running Honcho instances. Desktop-only — the web
+ * build can't port-scan due to CORS, so this returns an empty list when not
+ * running inside Tauri.
+ */
+export async function discoverHonchoInstances(): Promise<DiscoveredInstance[]> {
+	if (!isTauri()) return [];
+	const { invoke } = await import("@tauri-apps/api/core");
+	return invoke<DiscoveredInstance[]>("discover_honcho_instances");
+}
+
+/**
+ * Derive a friendly agent name from a workspace ID. Honcho workspaces follow
+ * the convention `<agent>-<camp>` (e.g. "neo-personal", "jeeves-codewalnut"),
+ * so we take the prefix and capitalize it. Falls back to the full ID if no
+ * hyphen is present.
+ */
+export function deriveNameFromWorkspaceId(workspaceId: string): string {
+	const first = workspaceId.split("-")[0] || workspaceId;
+	return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+/**
+ * Probe a discovered instance for its first workspace and derive a suggested
+ * name from it. Returns `null` if the instance has no workspaces or the
+ * request fails.
+ */
+export async function suggestNameForInstance(baseUrl: string): Promise<string | null> {
+	try {
+		const res = await httpFetch(`${baseUrl}/v3/workspaces/list?page=1&page_size=1`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+			signal: AbortSignal.timeout(2000),
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { items?: Array<{ id?: string }> };
+		const wsId = data.items?.[0]?.id;
+		if (typeof wsId === "string" && wsId.length > 0) {
+			return deriveNameFromWorkspaceId(wsId);
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/web/src/lib/fleetDream.ts
+++ b/packages/web/src/lib/fleetDream.ts
@@ -1,0 +1,154 @@
+import { createScopedClient, type ScopedClient } from "@/api/scopedClient";
+import type { Instance } from "@/lib/config";
+
+export interface FleetDreamTarget {
+	instance: Instance;
+	workspaceId: string;
+	peerId: string;
+}
+
+export type FleetDreamStatus = "pending" | "running" | "success" | "error";
+
+export interface FleetDreamStepResult extends FleetDreamTarget {
+	status: FleetDreamStatus;
+	error?: string;
+}
+
+const PAGE_SIZE = 100;
+
+/**
+ * Resolve every (workspace, peer) target for each instance by paginating both
+ * lists. A failure to enumerate one instance does not block others — instead,
+ * that instance is omitted from the targets and its error surfaces via
+ * onInstanceError so the UI can render it.
+ */
+export async function planFleetTargets(
+	instances: Instance[],
+	opts: {
+		makeClient?: (instance: Instance) => ScopedClient;
+		onInstanceError?: (instance: Instance, error: Error) => void;
+	} = {},
+): Promise<FleetDreamTarget[]> {
+	const makeClient = opts.makeClient ?? createScopedClient;
+	const out: FleetDreamTarget[] = [];
+
+	for (const instance of instances) {
+		try {
+			const client = makeClient(instance);
+			for (const workspaceId of await listAll(client, "workspaces", undefined)) {
+				for (const peerId of await listAll(client, "peers", workspaceId)) {
+					out.push({ instance, workspaceId, peerId });
+				}
+			}
+		} catch (e) {
+			opts.onInstanceError?.(instance, e instanceof Error ? e : new Error(String(e)));
+		}
+	}
+
+	return out;
+}
+
+async function listAll(
+	client: ScopedClient,
+	kind: "workspaces" | "peers",
+	workspaceId: string | undefined,
+): Promise<string[]> {
+	const ids: string[] = [];
+	let page = 1;
+	while (true) {
+		const res =
+			kind === "workspaces"
+				? await client.POST("/v3/workspaces/list", {
+						params: { query: { page, page_size: PAGE_SIZE } },
+						body: {},
+					})
+				: await client.POST("/v3/workspaces/{workspace_id}/peers/list", {
+						params: {
+							path: { workspace_id: workspaceId as string },
+							query: { page, page_size: PAGE_SIZE },
+						},
+						body: {},
+					});
+		if (res.error) throw new Error(JSON.stringify(res.error));
+		const data = res.data as { items?: Array<{ id: string }>; pages?: number } | undefined;
+		for (const item of data?.items ?? []) ids.push(item.id);
+		const pages = data?.pages ?? 1;
+		if (page >= pages) break;
+		page += 1;
+	}
+	return ids;
+}
+
+/**
+ * Fire schedule_dream for every target sequentially. Returns one result per
+ * target so the UI can render per-step status. Each request is scoped to its
+ * instance's baseUrl via makeClient.
+ */
+export async function fanOutDreams(
+	targets: FleetDreamTarget[],
+	opts: {
+		makeClient?: (instance: Instance) => ScopedClient;
+		onProgress?: (result: FleetDreamStepResult, index: number) => void;
+	} = {},
+): Promise<FleetDreamStepResult[]> {
+	const makeClient = opts.makeClient ?? createScopedClient;
+	const results: FleetDreamStepResult[] = [];
+
+	for (let i = 0; i < targets.length; i++) {
+		const target = targets[i];
+		opts.onProgress?.({ ...target, status: "running" }, i);
+		try {
+			const client = makeClient(target.instance);
+			const { error } = await client.POST("/v3/workspaces/{workspace_id}/schedule_dream", {
+				params: { path: { workspace_id: target.workspaceId } },
+				body: {
+					observer: target.peerId,
+					observed: target.peerId,
+					dream_type: "omni",
+				},
+			});
+			if (error) throw new Error(JSON.stringify(error));
+			const ok: FleetDreamStepResult = { ...target, status: "success" };
+			results.push(ok);
+			opts.onProgress?.(ok, i);
+		} catch (e) {
+			const err: FleetDreamStepResult = {
+				...target,
+				status: "error",
+				error: e instanceof Error ? e.message : String(e),
+			};
+			results.push(err);
+			opts.onProgress?.(err, i);
+		}
+	}
+
+	return results;
+}
+
+export interface FleetInstanceSummary {
+	instanceId: string;
+	instanceName: string;
+	total: number;
+	success: number;
+	failed: number;
+}
+
+export function summarizeByInstance(
+	results: FleetDreamStepResult[],
+): Map<string, FleetInstanceSummary> {
+	const acc = new Map<string, FleetInstanceSummary>();
+	for (const r of results) {
+		const entry = acc.get(r.instance.id) ?? {
+			instanceId: r.instance.id,
+			instanceName: r.instance.name,
+			total: 0,
+			success: 0,
+			failed: 0,
+		};
+		entry.total += 1;
+		if (r.status === "success") entry.success += 1;
+		else if (r.status === "error") entry.failed += 1;
+		acc.set(r.instance.id, entry);
+	}
+	return acc;
+}

--- a/packages/web/src/lib/toast.ts
+++ b/packages/web/src/lib/toast.ts
@@ -1,0 +1,51 @@
+export type ToastKind = "success" | "error" | "info";
+
+export interface Toast {
+	id: number;
+	message: string;
+	kind: ToastKind;
+}
+
+const DEFAULT_DURATION_MS = 3500;
+
+let toasts: Toast[] = [];
+let nextId = 1;
+const listeners = new Set<() => void>();
+
+function emit() {
+	for (const cb of listeners) cb();
+}
+
+export function subscribeToasts(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}
+
+export function getToasts(): Toast[] {
+	return toasts;
+}
+
+export function dismissToast(id: number): void {
+	toasts = toasts.filter((t) => t.id !== id);
+	emit();
+}
+
+export function toast(
+	message: string,
+	opts: { kind?: ToastKind; durationMs?: number } = {},
+): number {
+	const id = nextId++;
+	const entry: Toast = { id, message, kind: opts.kind ?? "success" };
+	toasts = [...toasts, entry];
+	emit();
+	const duration = opts.durationMs ?? DEFAULT_DURATION_MS;
+	if (duration > 0 && typeof window !== "undefined") {
+		window.setTimeout(() => dismissToast(id), duration);
+	}
+	return id;
+}
+
+export function clearToasts(): void {
+	toasts = [];
+	emit();
+}

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkspacesRouteImport } from './routes/workspaces'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ExploreRouteImport } from './routes/explore'
+import { Route as CompareRouteImport } from './routes/compare'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspacesWorkspaceIdRouteImport } from './routes/workspaces_.$workspaceId'
 import { Route as WorkspacesWorkspaceIdWebhooksRouteImport } from './routes/workspaces_.$workspaceId_.webhooks'
@@ -35,6 +36,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const ExploreRoute = ExploreRouteImport.update({
   id: '/explore',
   path: '/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompareRoute = CompareRouteImport.update({
+  id: '/compare',
+  path: '/compare',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -92,6 +98,7 @@ const WorkspacesWorkspaceIdPeersPeerIdChatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -121,6 +129,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/compare': typeof CompareRoute
   '/explore': typeof ExploreRoute
   '/settings': typeof SettingsRoute
   '/workspaces': typeof WorkspacesRoute
@@ -137,6 +146,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -151,6 +161,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -165,6 +176,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/compare'
     | '/explore'
     | '/settings'
     | '/workspaces'
@@ -180,6 +192,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CompareRoute: typeof CompareRoute
   ExploreRoute: typeof ExploreRoute
   SettingsRoute: typeof SettingsRoute
   WorkspacesRoute: typeof WorkspacesRoute
@@ -214,6 +227,13 @@ declare module '@tanstack/react-router' {
       path: '/explore'
       fullPath: '/explore'
       preLoaderRoute: typeof ExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/compare': {
+      id: '/compare'
+      path: '/compare'
+      fullPath: '/compare'
+      preLoaderRoute: typeof CompareRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -284,6 +304,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CompareRoute: CompareRoute,
   ExploreRoute: ExploreRoute,
   SettingsRoute: SettingsRoute,
   WorkspacesRoute: WorkspacesRoute,

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Outlet, redirect } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { Sidebar } from "@/components/layout/Sidebar";
+import { Toaster } from "@/components/shared/Toaster";
 import { loadConfig } from "@/lib/config";
 import { applyTheme, getStoredTheme } from "@/lib/theme";
 
@@ -20,6 +21,7 @@ function RootLayout() {
 			<main className="flex-1 overflow-auto" style={{ position: "relative", zIndex: 1 }}>
 				<Outlet />
 			</main>
+			<Toaster />
 		</div>
 	);
 }

--- a/packages/web/src/routes/compare.tsx
+++ b/packages/web/src/routes/compare.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompareView } from "@/components/compare/CompareView";
+
+interface CompareSearch {
+	instances?: string;
+	peer?: string;
+}
+
+export const Route = createFileRoute("/compare")({
+	validateSearch: (search: Record<string, unknown>): CompareSearch => ({
+		instances: typeof search.instances === "string" ? search.instances : undefined,
+		peer: typeof search.peer === "string" ? search.peer : undefined,
+	}),
+	component: CompareView,
+});

--- a/packages/web/src/test/compare.test.tsx
+++ b/packages/web/src/test/compare.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DemoProvider } from "@/context/DemoContext";
+import { MetadataProvider } from "@/context/MetadataContext";
+import { saveStore } from "@/lib/config";
+import { routeTree } from "@/routeTree.gen";
+
+function renderAt(initialPath: string) {
+	const router = createRouter({
+		routeTree,
+		history: createMemoryHistory({ initialEntries: [initialPath] }),
+	});
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={qc}>
+			<DemoProvider>
+				<MetadataProvider>
+					{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+					<RouterProvider router={router as any} />
+				</MetadataProvider>
+			</DemoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("Compare route", () => {
+	it("prompts the user to add instances when none are selected", async () => {
+		saveStore({
+			instances: [
+				{ id: "neo", name: "Neo", baseUrl: "http://localhost:8001", token: "" },
+				{ id: "iris", name: "Iris", baseUrl: "http://localhost:8002", token: "" },
+			],
+			activeId: "neo",
+		});
+		renderAt("/compare");
+		expect(await screen.findByText(/Pick instances to compare/i)).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/test/discovery.test.ts
+++ b/packages/web/src/test/discovery.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { deriveNameFromWorkspaceId } from "@/lib/discovery";
+
+describe("deriveNameFromWorkspaceId", () => {
+	it("capitalizes the prefix before the first hyphen", () => {
+		expect(deriveNameFromWorkspaceId("neo-personal")).toBe("Neo");
+	});
+
+	it("handles a multi-segment workspace id by taking only the first segment", () => {
+		expect(deriveNameFromWorkspaceId("jeeves-codewalnut-work")).toBe("Jeeves");
+	});
+
+	it("falls back to capitalizing the full id when there is no hyphen", () => {
+		expect(deriveNameFromWorkspaceId("standalone")).toBe("Standalone");
+	});
+});

--- a/packages/web/src/test/fleet-dream.test.ts
+++ b/packages/web/src/test/fleet-dream.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ScopedClient } from "@/api/scopedClient";
+import type { Instance } from "@/lib/config";
+import {
+	type FleetDreamTarget,
+	fanOutDreams,
+	planFleetTargets,
+	summarizeByInstance,
+} from "@/lib/fleetDream";
+
+function instance(id: string, port: number): Instance {
+	return {
+		id,
+		name: id,
+		baseUrl: `http://localhost:${port}`,
+		token: `tok-${id}`,
+	};
+}
+
+/**
+ * Build a fake ScopedClient factory that records every call's instance, path,
+ * body, and workspace path-param. Returns canned responses for
+ * /workspaces/list and /peers/list. The factory closure captures which
+ * instance each call was scoped to — that's how we verify per-instance
+ * routing without spinning up a real client.
+ */
+function buildFactory(
+	workspacesByInstance: Record<string, string[]>,
+	peersByInstance: Record<string, Record<string, string[]>>,
+) {
+	const calls: Array<{
+		instanceId: string;
+		path: string;
+		body?: unknown;
+		workspaceId?: string;
+	}> = [];
+
+	const makeClient = (inst: Instance): ScopedClient => {
+		const fake = {
+			async POST(
+				path: string,
+				opts: { params?: { path?: { workspace_id?: string } }; body?: unknown },
+			) {
+				calls.push({
+					instanceId: inst.id,
+					path,
+					body: opts.body,
+					workspaceId: opts.params?.path?.workspace_id,
+				});
+				if (path === "/v3/workspaces/list") {
+					const ids = workspacesByInstance[inst.id] ?? [];
+					return {
+						data: { items: ids.map((id) => ({ id })), pages: 1, total: ids.length },
+						error: undefined,
+					};
+				}
+				if (path === "/v3/workspaces/{workspace_id}/peers/list") {
+					const wsId = opts.params?.path?.workspace_id as string;
+					const ids = peersByInstance[inst.id]?.[wsId] ?? [];
+					return {
+						data: { items: ids.map((id) => ({ id })), pages: 1, total: ids.length },
+						error: undefined,
+					};
+				}
+				if (path === "/v3/workspaces/{workspace_id}/schedule_dream") {
+					return { data: undefined, error: undefined };
+				}
+				return { data: undefined, error: { message: "unhandled path" } };
+			},
+		};
+		return fake as unknown as ScopedClient;
+	};
+
+	return { makeClient, calls };
+}
+
+describe("planFleetTargets", () => {
+	it("fans out to every (instance, workspace, peer) triple", async () => {
+		const instances = [instance("neo", 8001), instance("iris", 8002), instance("lexi", 8003)];
+		const { makeClient } = buildFactory(
+			{ neo: ["ws-a", "ws-b"], iris: ["ws-c"], lexi: ["ws-d", "ws-e"] },
+			{
+				neo: { "ws-a": ["p1", "p2"], "ws-b": ["p3"] },
+				iris: { "ws-c": ["p4", "p5"] },
+				lexi: { "ws-d": ["p6"], "ws-e": ["p7", "p8"] },
+			},
+		);
+
+		const targets = await planFleetTargets(instances, { makeClient });
+
+		// neo: 2+1, iris: 2, lexi: 1+2  →  3 + 2 + 3 = 8 triples
+		expect(targets).toHaveLength(8);
+	});
+
+	it("isolates failures so one instance's error doesn't drop the others", async () => {
+		const instances = [instance("neo", 8001), instance("iris", 8002)];
+		const onInstanceError = vi.fn();
+		const makeClient = (inst: Instance): ScopedClient => {
+			const fake = {
+				async POST(path: string) {
+					if (inst.id === "neo") throw new Error("network down");
+					if (path === "/v3/workspaces/list") {
+						return { data: { items: [{ id: "ws-c" }], pages: 1, total: 1 }, error: undefined };
+					}
+					return { data: { items: [{ id: "p4" }], pages: 1, total: 1 }, error: undefined };
+				},
+			};
+			return fake as unknown as ScopedClient;
+		};
+
+		const targets = await planFleetTargets(instances, { makeClient, onInstanceError });
+
+		expect(targets).toEqual([{ instance: instances[1], workspaceId: "ws-c", peerId: "p4" }]);
+		expect(onInstanceError).toHaveBeenCalledOnce();
+		expect(onInstanceError.mock.calls[0][0]).toBe(instances[0]);
+	});
+});
+
+describe("fanOutDreams", () => {
+	it("routes each request to its target instance's client", async () => {
+		const instances = [instance("neo", 8001), instance("iris", 8002)];
+		const factory = buildFactory({}, {});
+		const targets: FleetDreamTarget[] = [
+			{ instance: instances[0], workspaceId: "ws-a", peerId: "p1" },
+			{ instance: instances[0], workspaceId: "ws-a", peerId: "p2" },
+			{ instance: instances[1], workspaceId: "ws-c", peerId: "p4" },
+		];
+
+		await fanOutDreams(targets, { makeClient: factory.makeClient });
+
+		const dreamCalls = factory.calls.filter(
+			(c) => c.path === "/v3/workspaces/{workspace_id}/schedule_dream",
+		);
+		// One request per target — N×M fan-out preserved.
+		expect(dreamCalls).toHaveLength(3);
+
+		// Each request routed to the correct instance (verifies baseUrl scoping
+		// since the factory closes over inst.baseUrl).
+		expect(dreamCalls.map((c) => c.instanceId)).toEqual(["neo", "neo", "iris"]);
+
+		// Each request carries the right workspace path param and observer body.
+		expect(dreamCalls.map((c) => c.workspaceId)).toEqual(["ws-a", "ws-a", "ws-c"]);
+		expect(dreamCalls.map((c) => (c.body as { observer: string }).observer)).toEqual([
+			"p1",
+			"p2",
+			"p4",
+		]);
+	});
+
+	it("emits progress for every step and continues past per-step errors", async () => {
+		const instances = [instance("neo", 8001), instance("iris", 8002)];
+		const targets: FleetDreamTarget[] = [
+			{ instance: instances[0], workspaceId: "ws-a", peerId: "p1" },
+			{ instance: instances[1], workspaceId: "ws-c", peerId: "p4" },
+		];
+		const makeClient = (inst: Instance): ScopedClient => {
+			const fake = {
+				async POST() {
+					if (inst.id === "iris") return { data: undefined, error: { message: "boom" } };
+					return { data: undefined, error: undefined };
+				},
+			};
+			return fake as unknown as ScopedClient;
+		};
+		const onProgress = vi.fn();
+
+		const results = await fanOutDreams(targets, { makeClient, onProgress });
+
+		expect(results.map((r) => r.status)).toEqual(["success", "error"]);
+		// onProgress fires running+terminal for each step → 4 calls.
+		expect(onProgress).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe("summarizeByInstance", () => {
+	it("groups results by instance and counts success/failure", () => {
+		const a = instance("neo", 8001);
+		const b = instance("iris", 8002);
+		const summary = summarizeByInstance([
+			{ instance: a, workspaceId: "w", peerId: "p1", status: "success" },
+			{ instance: a, workspaceId: "w", peerId: "p2", status: "error", error: "x" },
+			{ instance: b, workspaceId: "w", peerId: "p3", status: "success" },
+		]);
+
+		expect(summary.get("neo")).toEqual({
+			instanceId: "neo",
+			instanceName: "neo",
+			total: 2,
+			success: 1,
+			failed: 1,
+		});
+		expect(summary.get("iris")?.success).toBe(1);
+	});
+});

--- a/packages/web/src/test/scoped-client.test.ts
+++ b/packages/web/src/test/scoped-client.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { createScopedClient } from "@/api/scopedClient";
+import type { Instance } from "@/lib/config";
+
+vi.mock("@/lib/http", () => ({
+	httpFetch: vi.fn(async () => new Response("{}", { status: 200 })),
+}));
+
+const instance: Instance = {
+	id: "inst-1",
+	name: "Neo",
+	baseUrl: "http://localhost:8001",
+	token: "secret-token",
+};
+
+describe("createScopedClient", () => {
+	it("issues requests to the instance baseUrl", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.url).toBe("http://localhost:8001/v3/keys");
+	});
+
+	it("attaches the instance token as a Bearer Authorization header", async () => {
+		const { httpFetch } = await import("@/lib/http");
+		const client = createScopedClient(instance);
+		await client.GET("/v3/keys" as never);
+
+		const request = (httpFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as Request;
+		expect(request.headers.get("Authorization")).toBe("Bearer secret-token");
+	});
+});


### PR DESCRIPTION
## Summary
- **Per-workspace "Dream now"** — peer-picker modal (datalist powered by `usePeers`), defaults `observed → observer` for self-representation, toasts `"Dream queued for {observer}"` on success.
- **Fleet "Dream fleet"** — new button in the sidebar footer opens a dialog that enumerates every `(instance, workspace, peer)` triple via the existing scoped-client pattern, fires `schedule_dream` per target sequentially, and renders per-instance progress + error rollups.
- **Toaster** — lightweight external-store toast utility (no new deps) mounted at `__root.tsx` so future mutations can signal success without infrastructure churn.

### Motivation
Benchmarking workflow is: swap an agent's dreamer model → fire a dream → inspect output → repeat. Today dreams only run on the 8h cron, so each model swap costs hours. These two triggers cover both the per-agent and whole-fleet cases.

## Test plan
- [x] `pnpm --filter @openconcho/web test src/test/fleet-dream.test.ts` — 5/5 pass
  - Fan-out: `N × W × P` triples generated correctly
  - Per-instance failure during planning is isolated and surfaced via `onInstanceError`
  - Each `schedule_dream` request is routed to its target instance's client (verifies baseUrl scoping)
  - Progress callback fires running+terminal for every step
  - `summarizeByInstance` aggregates success/failed counts
- [x] `pnpm --filter @openconcho/web typecheck` clean
- [x] `pnpm --filter @openconcho/web lint` clean
- [x] `pnpm --filter @openconcho/web build` succeeds
- [ ] Manual: open WorkspaceDetail → "Dream now" → pick observer → submit → see toast
- [ ] Manual: click "Dream fleet" in sidebar footer → confirm → watch per-instance progress fill in

> Pre-existing `app.test.tsx` failure (`useMetadataContext must be used within MetadataProvider`) is present on `main` and not caused by this PR — verified by stashing the diff and rerunning.

## Notes
- Fleet fan-out is sequential per-target so backend queues don't drown in parallel requests; happy to switch to `Promise.allSettled` if the API can handle it.
- `Toaster` is intentionally minimal (~80 LOC across 2 files). If you'd rather adopt `sonner` or similar, easy to swap — call sites only depend on `toast()` from `@/lib/toast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)