### PR TITLE
test(web): wrap test harness in MetadataProvider to match production

### DIFF
--- a/packages/web/src/test/app.test.tsx
+++ b/packages/web/src/test/app.test.tsx
@@ -3,6 +3,7 @@ import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/rea
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DemoProvider } from "@/context/DemoContext";
+import { MetadataProvider } from "@/context/MetadataContext";
 import { useDemo } from "@/hooks/useDemo";
 import { routeTree } from "@/routeTree.gen";
 
@@ -15,8 +16,10 @@ function renderAt(initialPath: string) {
 	return render(
 		<QueryClientProvider client={qc}>
 			<DemoProvider>
-				{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
-				<RouterProvider router={router as any} />
+				<MetadataProvider>
+					{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+					<RouterProvider router={router as any} />
+				</MetadataProvider>
 			</DemoProvider>
 		</QueryClientProvider>,
 	);
@@ -56,9 +59,11 @@ describe("Sidebar/useDemo availability across routes", () => {
 			render(
 				<QueryClientProvider client={qc}>
 					<DemoProvider>
-						{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
-						<RouterProvider router={router as any} />
-						<DemoConsumer />
+						<MetadataProvider>
+							{/* biome-ignore lint/suspicious/noExplicitAny: test router type */}
+							<RouterProvider router={router as any} />
+							<DemoConsumer />
+						</MetadataProvider>
 					</DemoProvider>
 				</QueryClientProvider>,
 			);


### PR DESCRIPTION
## Problem

CI has been **red on `main` since `e490d91`** ("add global metadata visibility toggle"). That commit added `useMetadata()` to `Sidebar`, but the test render helpers in `app.test.tsx` only wrapped with `DemoProvider` — not `MetadataProvider`.

Result: the routed app throws `useMetadataContext must be used within MetadataProvider` in tests, the route error boundary swallows the tree, and the first-load empty-state assertion fails.

## Fix

Mirror the production provider nesting from `main.tsx` (`QueryClient > Demo > Metadata > Router`) in both render sites in `app.test.tsx`. No app code changes.

## Verification

`make check` — lint + typecheck + **11/11 tests pass** locally.

## Follow-up

Branch protection let three consecutive red runs land on `main`. Worth enabling a required green-CI gate (tracked separately).