### PR TITLE
ci(deps): add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,105 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # ─── JavaScript / pnpm workspace ──────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      # Keep TanStack libs in lockstep — they release as a family
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      # Tauri JS bindings
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
+      # Test stack
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jsdom"
+          - "@playwright/*"
+      # Build/lint tooling
+      tooling:
+        patterns:
+          - "@biomejs/*"
+          - "turbo"
+          - "vite"
+          - "@vitejs/*"
+          - "typescript"
+      # React core
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # Semantic-release ecosystem
+      semantic-release:
+        patterns:
+          - "semantic-release"
+          - "@semantic-release/*"
+      # Commitlint + husky
+      commit-tooling:
+        patterns:
+          - "@commitlint/*"
+          - "husky"
+
+  # ─── Rust / Cargo (Tauri desktop shell) ───────────────────────────────────
+  - package-ecosystem: "cargo"
+    directory: "/packages/desktop/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      tauri-core:
+        patterns:
+          - "tauri"
+          - "tauri-*"
+      tokio:
+        patterns:
+          - "tokio"
+          - "tokio-*"
+          - "futures"
+          - "futures-*"
+
+  # ─── GitHub Actions workflow pins ─────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Weekly dependency updates across all three ecosystems, grouped so related bumps land together instead of as PR spam:
- **npm** (pnpm workspace at `/`) — grouped: TanStack, Tauri JS, React, test stack, build tooling, semantic-release, commitlint.
- **cargo** (`/packages/desktop/src-tauri`) — grouped: tauri-core, tokio.
- **github-actions** — workflow pin updates.

Config-only; conventional `chore(deps)` / `chore(ci)` commit prefixes so semantic-release ignores them. CODEOWNERS from the source branch was omitted (it was hardcoded to the fork author).

## Credit
From @BenSheridanEdwards's fork (`chore/branch-protection-bots`). Thanks Ben!