### PR TITLE
fix(ci): trigger release build on release publish, not tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Problem
The Tauri artifact build (`release.yml`) has **never auto-triggered** — all historical runs are manual `workflow_dispatch`. v0.12.0 shipped with **zero assets** until hand-dispatched.

## Root cause
`@semantic-release/github` creates the tag via the **GitHub Releases API**. API-created tags don't emit the `refs/tags/*` push event that `on: push: tags: ['v*']` listens for. (The `RELEASE_TOKEN` is a real PAT — verified: v0.12.0's release author is `offendingcommit`, not a bot — so the token was never the issue.)

## Fix
Trigger on `release: published`, which the PAT-published release *does* fire. `workflow_dispatch` stays as a manual fallback. Existing steps already resolve `github.ref_name`/`github.ref` to the tag on a release event, so no step changes needed.

## Verification
Next release will auto-build artifacts on publish. (v0.12.0 is being backfilled by an in-flight manual dispatch.)