### PR TITLE
ci(docker): link GHCR package to repo via index annotation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to (re)build and publish, e.g. v0.13.0. Defaults to the triggering ref.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -15,6 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # Derive the image version from the tag (release ref or dispatch input) so
+      # raw tags work for both triggers — semver-from-ref doesn't fire on dispatch.
+      - id: ver
+        shell: bash
+        run: |
+          REF="${{ github.event.inputs.tag || github.ref_name }}"
+          V="${REF#v}"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "minor=${V%.*}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -27,11 +44,15 @@ jobs:
 
       - id: meta
         uses: docker/metadata-action@v5
+        # Annotate the INDEX (not just per-platform configs) so GHCR can read
+        # org.opencontainers.image.source and auto-link the package to the repo.
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
           images: ghcr.io/${{ github.repository_owner }}/openconcho-web
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ steps.ver.outputs.version }}
+            type=raw,value=${{ steps.ver.outputs.minor }}
             type=raw,value=latest
             type=sha,format=short
 
@@ -40,7 +61,11 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          # provenance off keeps the pushed artifact a plain multi-arch index,
+          # so the index annotation below is what GHCR sees for repo linking.
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Why
The published web image isn't attached to the repo (no Packages widget). Root cause: the publish step passed `labels` but not `annotations`, so `org.opencontainers.image.source` only landed on the per-platform image configs — never on the multi-arch **index**, which is what GHCR reads to auto-link a package to its repo.

## Fix (durable)
- `DOCKER_METADATA_ANNOTATIONS_LEVELS=index` + pass `annotations` to build-push-action → source/url/revision on the index.
- `provenance: false` so the pushed artifact is a clean multi-arch index (no attestation manifests obscuring the source annotation).
- `workflow_dispatch` gains a `tag` input so we can **republish a specific version** (tags derived from the ref, so both dispatch and release work).

Type `ci` → no version bump. After merge I'll dispatch this for **v0.13.0** to republish the same version with the index annotation, which links the existing package.

No app code touched.