### PR TITLE
build(docker): bake image source label for GHCR repo linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ RUN pnpm --filter @openconcho/web build
 # under a read-only filesystem with cap_drop ALL.
 FROM nginxinc/nginx-unprivileged:alpine
 
+# Baked into the image config — the canonical, build-tool-independent signal GHCR
+# reads to connect the published package to this repo. Evaluated at package
+# creation, so it links freshly-created packages without relying on buildx
+# annotation levels.
+LABEL org.opencontainers.image.source="https://github.com/offendingcommit/openconcho"
+
 COPY --chown=101:101 --from=builder /app/packages/web/dist /usr/share/nginx/html
 # Rendered to /etc/nginx/conf.d/default.conf by the image's envsubst entrypoint.
 COPY --chown=101:101 docker/nginx.conf.template /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
## Why
The published web image isn't linked to the repo. The canonical, documented mechanism for **container** packages is a `LABEL org.opencontainers.image.source` **baked into the image config** — not the buildx/metadata-action annotations we'd been tuning.

## Change
One line in the Dockerfile's runtime stage:
```dockerfile
LABEL org.opencontainers.image.source="https://github.com/offendingcommit/openconcho"
```
**Verified locally**: `docker inspect` confirms the label is in the final image config.

## Important: this links *new* packages, not the existing orphan
GHCR evaluates the source at **package creation**, not on every push. So:
- **Existing `openconcho-web` package** (already orphaned): needs a one-time fix — either the manual **Package settings → Connect repository** UI step, or **delete the package + re-publish** (fresh creation auto-connects with this label). There's no REST endpoint to connect, so it can't be automated.
- **Future packages**: auto-connect from this label, no manual step.

Type `build` → no version bump.