### PR TITLE
chore: harden against environment-specific leaks

### DIFF
--- a/packages/web/src/test/security.test.ts
+++ b/packages/web/src/test/security.test.ts
@@ -27,11 +27,11 @@ describe("security URL helpers", () => {
 		expect(isSecureTokenTransport("http://localhost:8000")).toBe(true);
 		expect(isSecureTokenTransport("http://127.0.0.1:8000")).toBe(true);
 		expect(isSecureTokenTransport("http://192.168.1.50:8000")).toBe(false);
-		expect(isSecureTokenTransport("http://100.67.206.76:8000")).toBe(false);
+		expect(isSecureTokenTransport("http://192.0.2.10:8000")).toBe(false);
 	});
 
 	it("returns a user-facing error for insecure token transport", () => {
-		expect(tokenTransportError("http://100.67.206.76:8000")).toMatch(/HTTPS/);
+		expect(tokenTransportError("http://192.0.2.10:8000")).toMatch(/HTTPS/);
 		expect(tokenTransportError("https://honcho.example.com")).toBeNull();
 	});
 });

--- a/packages/web/src/test/settings-form.test.tsx
+++ b/packages/web/src/test/settings-form.test.tsx
@@ -58,7 +58,7 @@ describe("SettingsForm — self-hosted preset", () => {
 		renderForm(<SettingsForm instance={null} preset="self-hosted" />);
 		const baseUrl = screen.getByPlaceholderText("http://localhost:8000");
 		await user.clear(baseUrl);
-		await user.type(baseUrl, "http://100.67.206.76:8000");
+		await user.type(baseUrl, "http://192.0.2.10:8000");
 		await user.type(
 			screen.getByPlaceholderText(/required only if your instance has auth enabled/i),
 			"secret-token",

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -52,12 +52,17 @@ check_pattern "Honcho-style JWT (likely)" 'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_
 check_pattern "RSA/EC/DSA/OpenSSH private key block" '-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----'
 check_pattern "Generic hardcoded password" '(password|passwd|pwd)[[:space:]]*[:=][[:space:]]*["'\'']\w{8,}["'\'']'
 
+# Environment-specific values — keep live infra out of committed code/docs/PRs.
+# Use examples instead (honcho.example.net; 192.0.2.x per RFC 5737 TEST-NET).
+check_pattern "Tailnet hostname (env-specific; use example.net)" '[A-Za-z0-9-]+\.ts\.net'
+check_pattern "Tailnet/CGNAT IP (env-specific; use 192.0.2.x)" '100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}'
+
 if [ $FOUND -eq 1 ]; then
-  printf '\n\033[31m✗ Secret scan: potential secrets in staged changes\033[0m\n' >&2
+  printf '\n\033[31m✗ Secret scan: potential secrets or environment-specific values in staged changes\033[0m\n' >&2
   printf '%b' "$FINDINGS" >&2
   printf '\n' >&2
   printf 'If this is a false positive, bypass with:  \033[33mgit commit --no-verify\033[0m\n' >&2
-  printf 'Otherwise: remove the secret, rotate the credential, and re-stage.\n\n' >&2
+  printf 'Otherwise: remove the secret/value (use an example), rotate if a credential, and re-stage.\n\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
Two small hygiene changes (separate concern from #54):

1. **test(web):** replace the `100.x` CGNAT fixture in the token-transport guard tests with `192.0.2.10` (RFC 5737 TEST-NET-1) — a clearly-example, non-loopback address. Same assertions, no environment-specific IP.
2. **chore(hooks):** extend the pre-commit `scripts/secret-scan.sh` to flag `*.ts.net` MagicDNS names and `100.64.0.0/10` tailnet IPs, so live infra can't be committed into code, docs, or examples going forward.

Verified the guard detects leaks, has no false positive on `192.0.2.x` / non-CGNAT `100.x`, and does not self-trip on its own pattern definitions. Use examples (`honcho.example.net`, `192.0.2.x`) instead.