### PR TITLE
fix(docker): fix Nginx path #66

### DIFF
--- a/charts/openconcho/values.yaml
+++ b/charts/openconcho/values.yaml
@@ -53,6 +53,7 @@ securityContext:
 # Directories mounted as ephemeral tmpfs (in-memory) to satisfy nginx's write requirements
 # when the root filesystem is read-only. Add entries for any additional writable paths.
 tmpfsMounts:
+  - mountPath: /etc/nginx/conf.d
   - mountPath: /var/cache/nginx
   - mountPath: /var/run
   - mountPath: /tmp

--- a/docker/40-openconcho-config.sh
+++ b/docker/40-openconcho-config.sh
@@ -3,11 +3,11 @@
 # Lets one prebuilt image target any Honcho backend without a rebuild.
 #   OPENCONCHO_DEFAULT_HONCHO_URL — absolute URL seeding the first instance, or empty.
 #   OPENCONCHO_UPSTREAM_ALLOWLIST — optional comma-separated host globs (SSRF guard).
-# Runs from /docker-entrypoint.d before nginx starts. Requires the html dir to
-# be writable (default); skip or bind-mount config.js when running --read-only.
+# Runs from /docker-entrypoint.d before nginx starts. Writes config.js to /tmp
+# so the container works cleanly under a read-only root filesystem.
 set -eu
 
-cat > /usr/share/nginx/html/config.js <<EOF
+cat > /tmp/openconcho-config.js <<EOF
 window.__OPENCONCHO_DEFAULT_HONCHO_URL__ = "${OPENCONCHO_DEFAULT_HONCHO_URL:-}";
 EOF
 

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -39,7 +39,7 @@ server {
     # Runtime config — regenerated per container start, must never be cached.
     location = /config.js {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
-        try_files $uri =404;
+        alias /tmp/openconcho-config.js;
     }
 
     # Long-cache static assets — Vite hashes filenames so they're immutable.


### PR DESCRIPTION
## Summary

### Root Cause
The Helm chart deploys with `readOnlyRootFilesystem: true`, but the `tmpfsMounts` was missing two directories that nginx's entrypoint and the openconcho config script need to write to at startup:

`/etc/nginx/conf.d/` — where nginx renders the template and the config script writes `00-resolver.conf / allowlist_map.conf`
`/usr/share/nginx/html/` — where the config script was writing `config.js`

### Fix Applied
Three files changed:

`charts/openconcho/values.yaml:55-59`: Added /etc/nginx/conf.d to tmpfsMounts

`docker/40-openconcho-config.sh:10`: Changed output path from `/usr/share/nginx/html/config.js to /tmp/openconcho-config.js`

`docker/nginx.conf.template:40-43`: Updated the `/config.js` location to serve from `/tmp/openconcho-config.js` via alias instead of try_files

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` succeeds
- [ ] Tested in browser (describe what you verified)

## Related issues

#66 
