### PR TITLE
docker: support IPv6 nameservers in nginx resolver derivation

### DIFF
--- a/docker/40-openconcho-config.sh
+++ b/docker/40-openconcho-config.sh
@@ -15,9 +15,12 @@ EOF
 # proxy_pass resolves on BOTH user-defined networks (Docker embedded DNS at
 # 127.0.0.11) and the default bridge (host nameservers from /etc/resolv.conf).
 # Hardcoding 127.0.0.11 breaks `docker run` on the default bridge (no embedded DNS).
-RESOLVERS=$(awk '/^nameserver/ { print $2 }' /etc/resolv.conf | tr '\n' ' ' | sed 's/ *$//')
+# IPv6 nameservers (e.g. Fly.io's fdaa::3) must be bracketed, or nginx reads the
+# text after the last colon as a port and dies: [emerg] invalid port in resolver.
+RESOLVERS=$(awk '/^nameserver/ { print ($2 ~ /:/) ? "[" $2 "]" : $2 }' /etc/resolv.conf | tr '\n' ' ' | sed 's/ *$//')
 [ -z "$RESOLVERS" ] && RESOLVERS=127.0.0.11
-printf 'resolver %s ipv6=off valid=10s;\n' "$RESOLVERS" > /etc/nginx/conf.d/00-resolver.conf
+# No ipv6=off here: IPv6-only upstreams (e.g. Fly.io .flycast) need AAAA answers.
+printf 'resolver %s valid=10s;\n' "$RESOLVERS" > /etc/nginx/conf.d/00-resolver.conf
 
 # Render the SSRF allowlist into an nginx map for $allow_upstream.
 # Unset/empty OPENCONCHO_UPSTREAM_ALLOWLIST → open (default 1), fine for the


### PR DESCRIPTION
## Problem

`docker/40-openconcho-config.sh` derives nginx's `resolver` from the container's `/etc/resolv.conf`, but writes nameserver addresses verbatim. Two issues:

1. **IPv6 nameservers crash nginx at startup.** nginx requires IPv6 resolver addresses in brackets; unbracketed, it parses everything after the last colon as a port. On any host whose resolv.conf carries an IPv6 nameserver — e.g. Fly.io machines, where the resolver is `fdaa::3` — the container crash-loops with:

   ```
   nginx: [emerg] invalid port in resolver "fdaa::3" in /etc/nginx/conf.d/00-resolver.conf:1
   ```

2. **Hardcoded `ipv6=off` breaks IPv6-only upstreams.** With `ipv6=off`, nginx discards AAAA answers, so the header-driven `/api` proxy can never reach upstreams that only resolve to IPv6 — e.g. Fly.io private `.flycast` addresses.

## Fix

- Bracket any nameserver containing a colon when rendering `00-resolver.conf` (`fdaa::3` → `[fdaa::3]`), so nginx parses it as an IPv6 address instead of `host:port`.
- Drop the hardcoded `ipv6=off` so AAAA resolution works for IPv6-only upstreams. IPv4-only environments are unaffected: happy-eyeballs-style fallback still resolves A records as before.

## Testing

Ran the patched script inside `nginxinc/nginx-unprivileged:alpine` (busybox awk, same as the image build) followed by `nginx -t`:

| `/etc/resolv.conf` nameservers | rendered `00-resolver.conf` | `nginx -t` |
|---|---|---|
| `fdaa::3` (Fly.io) | `resolver [fdaa::3] valid=10s;` | ok |
| `fdaa::3` + `8.8.8.8` | `resolver [fdaa::3] 8.8.8.8 valid=10s;` | ok |
| _(empty)_ | `resolver 127.0.0.11 valid=10s;` (fallback) | ok |

Previously the first case rendered `resolver fdaa::3 ipv6=off valid=10s;` and nginx failed with the emerg above.

We hit this deploying the image on Fly.io; currently working around it with an extra entrypoint script that post-processes `00-resolver.conf`, but the derivation should be fixed at the source.
