### PR TITLE
fix(web): read conclusion level from the field Honcho actually sends

### DIFF
--- a/packages/web/e2e/dreams.spec.ts
+++ b/packages/web/e2e/dreams.spec.ts
@@ -21,76 +21,76 @@ test.describe("Dreams route", () => {
 		await context.route(
 			(url) => url.pathname.endsWith("/conclusions/list"),
 			async (route) => {
-			const now = Date.now();
-			const iso = (offsetMs: number) => new Date(now - offsetMs).toISOString();
-			const items = [
-				// Dream A — burst
-				{
-					id: "ind-1",
-					content: "Alice prefers asynchronous communication",
-					observer_id: "alice",
-					observed_id: "bob",
-					session_id: "sess-1",
-					created_at: iso(1000),
-					conclusion_type: "inductive",
-					reasoning_tree: {
-						conclusion_id: "ind-1",
-						premises: [{ conclusion_id: "ded-1" }],
+				const now = Date.now();
+				const iso = (offsetMs: number) => new Date(now - offsetMs).toISOString();
+				const items = [
+					// Dream A — burst
+					{
+						id: "ind-1",
+						content: "Alice prefers asynchronous communication",
+						observer_id: "alice",
+						observed_id: "bob",
+						session_id: "sess-1",
+						created_at: iso(1000),
+						level: "inductive",
+						reasoning_tree: {
+							conclusion_id: "ind-1",
+							premises: [{ conclusion_id: "ded-1" }],
+						},
 					},
-				},
-				{
-					id: "ded-1",
-					content: "Alice mentioned email twice and declined two meetings",
-					observer_id: "alice",
-					observed_id: "bob",
-					session_id: "sess-1",
-					created_at: iso(2000),
-					conclusion_type: "deductive",
-					reasoning_tree: {
-						conclusion_id: "ded-1",
-						premises: [{ conclusion_id: "exp-1" }, { conclusion_id: "exp-2" }],
+					{
+						id: "ded-1",
+						content: "Alice mentioned email twice and declined two meetings",
+						observer_id: "alice",
+						observed_id: "bob",
+						session_id: "sess-1",
+						created_at: iso(2000),
+						level: "deductive",
+						reasoning_tree: {
+							conclusion_id: "ded-1",
+							premises: [{ conclusion_id: "exp-1" }, { conclusion_id: "exp-2" }],
+						},
 					},
-				},
-				{
-					id: "exp-1",
-					content: "Alice said 'just email me'",
-					observer_id: "alice",
-					observed_id: "bob",
-					session_id: "sess-1",
-					created_at: iso(3000),
-					conclusion_type: "explicit",
-				},
-				{
-					id: "exp-2",
-					content: "Alice declined the Tuesday standup",
-					observer_id: "alice",
-					observed_id: "bob",
-					session_id: "sess-1",
-					created_at: iso(4000),
-					conclusion_type: "explicit",
-				},
-				// Dream B — 30 minutes ago, different pair → clusters separately
-				{
-					id: "ded-2",
-					content: "Carol responds in the evenings",
-					observer_id: "carol",
-					observed_id: "dan",
-					session_id: "sess-2",
-					created_at: iso(30 * 60_000),
-					conclusion_type: "deductive",
-				},
-			];
-			await route.fulfill({
-				status: 200,
-				contentType: "application/json",
-				body: JSON.stringify({
-					items,
-					total: items.length,
-					pages: 1,
-					page: 1,
-					size: items.length,
-				}),
-			});
+					{
+						id: "exp-1",
+						content: "Alice said 'just email me'",
+						observer_id: "alice",
+						observed_id: "bob",
+						session_id: "sess-1",
+						created_at: iso(3000),
+						level: "explicit",
+					},
+					{
+						id: "exp-2",
+						content: "Alice declined the Tuesday standup",
+						observer_id: "alice",
+						observed_id: "bob",
+						session_id: "sess-1",
+						created_at: iso(4000),
+						level: "explicit",
+					},
+					// Dream B — 30 minutes ago, different pair → clusters separately
+					{
+						id: "ded-2",
+						content: "Carol responds in the evenings",
+						observer_id: "carol",
+						observed_id: "dan",
+						session_id: "sess-2",
+						created_at: iso(30 * 60_000),
+						level: "deductive",
+					},
+				];
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify({
+						items,
+						total: items.length,
+						pages: 1,
+						page: 1,
+						size: items.length,
+					}),
+				});
 			},
 		);
 	});
@@ -115,7 +115,7 @@ test.describe("Dreams route", () => {
 		await page.goto("/workspaces/ws-test/dreams");
 
 		// Two dreams: alice→bob burst, and the older carol→dan
-		const rows = page.locator('button[aria-pressed]');
+		const rows = page.locator("button[aria-pressed]");
 		await expect(rows).toHaveCount(2);
 
 		// Alice→bob row should show count chips
@@ -135,7 +135,7 @@ test.describe("Dreams route", () => {
 
 	test("expands premise tree for an inductive conclusion", async ({ page }) => {
 		await page.goto("/workspaces/ws-test/dreams");
-		await page.locator('button[aria-pressed]').first().click();
+		await page.locator("button[aria-pressed]").first().click();
 
 		const showPremises = page.getByRole("button", { name: /^Show premises$/i });
 		await expect(showPremises).toBeVisible();

--- a/packages/web/src/components/dreams/DreamDetail.tsx
+++ b/packages/web/src/components/dreams/DreamDetail.tsx
@@ -34,6 +34,11 @@ const COLUMNS: Array<{ type: ConclusionType; label: string; description: string 
 		label: "Inductive",
 		description: "Generalized patterns inferred from deductives",
 	},
+	{
+		type: "contradiction",
+		label: "Contradiction",
+		description: "Conflicts found between existing observations",
+	},
 ];
 
 interface DreamDetailProps {
@@ -51,6 +56,7 @@ export function DreamDetail({ dream, onClose }: DreamDetailProps) {
 			explicit: [],
 			deductive: [],
 			inductive: [],
+			contradiction: [],
 		};
 		for (const c of dream.conclusions) {
 			buckets[inferConclusionType(c)].push(c);

--- a/packages/web/src/components/dreams/DreamList.tsx
+++ b/packages/web/src/components/dreams/DreamList.tsx
@@ -157,6 +157,9 @@ function DreamRow({ dream, active, onSelect }: DreamRowProps) {
 					<CountChip label="explicit" value={counts.explicit} kind="neutral" />
 					<CountChip label="deductive" value={counts.deductive} kind="accent" />
 					<CountChip label="inductive" value={counts.inductive} kind="warning" />
+					{counts.contradiction > 0 && (
+						<CountChip label="contradiction" value={counts.contradiction} kind="destructive" />
+					)}
 					<ChevronRight
 						className="w-4 h-4 ml-1 transition-transform"
 						style={{
@@ -177,7 +180,7 @@ function DreamRow({ dream, active, onSelect }: DreamRowProps) {
 	);
 }
 
-type ChipKind = "neutral" | "accent" | "warning";
+type ChipKind = "neutral" | "accent" | "warning" | "destructive";
 
 function CountChip({ label, value, kind }: { label: string; value: number; kind: ChipKind }) {
 	const palette: Record<ChipKind, { bg: string; fg: string; border: string }> = {
@@ -188,6 +191,11 @@ function CountChip({ label, value, kind }: { label: string; value: number; kind:
 		},
 		accent: { bg: COLOR.accentSubtle, fg: COLOR.accentText, border: COLOR.accentBorder },
 		warning: { bg: "rgba(245,158,11,0.10)", fg: COLOR.warning, border: COLOR.warningBorder },
+		destructive: {
+			bg: COLOR.destructiveDim,
+			fg: COLOR.destructive,
+			border: COLOR.destructiveBorder,
+		},
 	};
 	const cfg = palette[kind];
 	const dim = value === 0;

--- a/packages/web/src/components/dreams/PremiseTree.tsx
+++ b/packages/web/src/components/dreams/PremiseTree.tsx
@@ -27,6 +27,12 @@ const TYPE_BADGE: Record<
 		fg: COLOR.warning,
 		border: COLOR.warningBorder,
 	},
+	contradiction: {
+		label: "contradiction",
+		bg: COLOR.destructiveDim,
+		fg: COLOR.destructive,
+		border: COLOR.destructiveBorder,
+	},
 };
 
 export function ConclusionTypeBadge({ type }: { type: ConclusionType }) {

--- a/packages/web/src/lib/dreams.ts
+++ b/packages/web/src/lib/dreams.ts
@@ -2,20 +2,23 @@ import type { components } from "@/api/schema.d.ts";
 
 type ApiConclusion = components["schemas"]["Conclusion"];
 
-export type ConclusionType = "explicit" | "deductive" | "inductive";
+export type ConclusionType = "explicit" | "deductive" | "inductive" | "contradiction";
 
 export const CONCLUSION_TYPES: readonly ConclusionType[] = [
 	"explicit",
 	"deductive",
 	"inductive",
+	"contradiction",
 ] as const;
 
-// The generated OpenAPI schema does not yet expose `conclusion_type`, `premises`, or
-// `reasoning_tree` (Honcho migration f1a2b3c4d5e6 added the columns but the response
-// schema hasn't been regenerated client-side). We declare them as optional here so
-// the UI consumes them when present and degrades gracefully when absent.
+// The generated OpenAPI schema (Honcho 3.0.5) does not expose `level`, `premises`, or
+// `reasoning_tree`, but live Honcho 3.0.11 returns `level` on every conclusion.
+// Declared optional here so the UI consumes them when present and degrades gracefully
+// when absent. `premises`/`reasoning_tree` are still unserved — the premise tree stays
+// empty until Honcho ships them.
 export type ExtendedConclusion = ApiConclusion & {
-	conclusion_type?: ConclusionType | null;
+	/** Widened to `string`: Honcho may add levels this client doesn't know yet. */
+	level?: string | null;
 	premises?: string[] | null;
 	reasoning_tree?: ReasoningTreeNode | null;
 };
@@ -41,6 +44,7 @@ export interface DreamCounts {
 	explicit: number;
 	deductive: number;
 	inductive: number;
+	contradiction: number;
 	total: number;
 }
 
@@ -52,11 +56,17 @@ export interface ClusterOptions {
 const DEFAULT_GAP_MS = 60_000;
 
 export function inferConclusionType(c: ExtendedConclusion): ConclusionType {
-	return c.conclusion_type ?? "explicit";
+	return CONCLUSION_TYPES.find((t) => t === c.level) ?? "explicit";
 }
 
 export function dreamCounts(dream: Pick<Dream, "conclusions">): DreamCounts {
-	const counts: DreamCounts = { explicit: 0, deductive: 0, inductive: 0, total: 0 };
+	const counts: DreamCounts = {
+		explicit: 0,
+		deductive: 0,
+		inductive: 0,
+		contradiction: 0,
+		total: 0,
+	};
 	for (const c of dream.conclusions) {
 		counts[inferConclusionType(c)]++;
 		counts.total++;

--- a/packages/web/src/test/dreams.test.ts
+++ b/packages/web/src/test/dreams.test.ts
@@ -115,20 +115,27 @@ describe("clusterConclusionsIntoDreams", () => {
 		expect(dreams[0].latestMs).toBeGreaterThan(dreams[1].latestMs);
 	});
 
-	it("computes counts by inferred conclusion_type, defaulting unknown to explicit", () => {
+	it("computes counts by inferred level, defaulting unknown to explicit", () => {
 		const conclusions = [
 			mkConclusion("c1", iso(0)),
-			mkConclusion("c2", iso(2), { conclusion_type: "deductive" }),
-			mkConclusion("c3", iso(4), { conclusion_type: "deductive" }),
-			mkConclusion("c4", iso(6), { conclusion_type: "inductive" }),
+			mkConclusion("c2", iso(2), { level: "deductive" }),
+			mkConclusion("c3", iso(4), { level: "deductive" }),
+			mkConclusion("c4", iso(6), { level: "inductive" }),
 		];
 		const [dream] = clusterConclusionsIntoDreams(conclusions);
 		expect(dreamCounts(dream)).toEqual({
-			explicit: 1, // c1 has no type → defaults to explicit
+			explicit: 1, // c1 has no level → defaults to explicit
 			deductive: 2,
 			inductive: 1,
+			contradiction: 0,
 			total: 4,
 		});
+	});
+
+	it("counts a level this client does not know as explicit rather than dropping it", () => {
+		const conclusions = [mkConclusion("c1", iso(0), { level: "abductive" })];
+		const [dream] = clusterConclusionsIntoDreams(conclusions);
+		expect(dreamCounts(dream).explicit).toBe(1);
 	});
 });
 
@@ -144,10 +151,10 @@ describe("expandPremiseTree", () => {
 	});
 
 	it("expands a flat premises list to direct children", () => {
-		const p1 = mkConclusion("p1", iso(0), { conclusion_type: "explicit" });
-		const p2 = mkConclusion("p2", iso(1), { conclusion_type: "explicit" });
+		const p1 = mkConclusion("p1", iso(0), { level: "explicit" });
+		const p2 = mkConclusion("p2", iso(1), { level: "explicit" });
 		const top = mkConclusion("top", iso(5), {
-			conclusion_type: "inductive",
+			level: "inductive",
 			premises: ["p1", "p2"],
 		});
 		const index = buildPremiseIndex([p1, p2, top]);
@@ -158,17 +165,17 @@ describe("expandPremiseTree", () => {
 	});
 
 	it("walks a multi-level reasoning_tree recursively", () => {
-		const e1 = mkConclusion("e1", iso(0), { conclusion_type: "explicit" });
-		const e2 = mkConclusion("e2", iso(1), { conclusion_type: "explicit" });
+		const e1 = mkConclusion("e1", iso(0), { level: "explicit" });
+		const e2 = mkConclusion("e2", iso(1), { level: "explicit" });
 		const d1 = mkConclusion("d1", iso(2), {
-			conclusion_type: "deductive",
+			level: "deductive",
 			reasoning_tree: {
 				conclusion_id: "d1",
 				premises: [{ conclusion_id: "e1" }, { conclusion_id: "e2" }],
 			},
 		});
 		const ind = mkConclusion("ind", iso(3), {
-			conclusion_type: "inductive",
+			level: "inductive",
 			reasoning_tree: {
 				conclusion_id: "ind",
 				premises: [{ conclusion_id: "d1" }],


### PR DESCRIPTION
## Problem

Every dream card reports `0 deductive` and `0 inductive`, no matter what the backend actually produced.

`inferConclusionType` reads `conclusion_type`:

https://github.com/offendingcommit/openconcho/blob/main/packages/web/src/lib/dreams.ts#L55

No Honcho version returns that field. `git grep conclusion_type` finds it only in `dreams.ts` and its own tests — nothing produces it, so the `?? "explicit"` fallback fires for every conclusion and the deductive/inductive chips are structurally pinned to zero.

The real field is `level`. From Honcho's own SDKs:

```python
# sdks/python/src/honcho/api_types.py
class Conclusion(BaseModel):
    id: str
    content: str
    observer_id: str
    observed_id: str
    session_id: str | None = None
    level: ConclusionLevel = "explicit"
    created_at: datetime.datetime
```

```ts
// sdks/typescript/src/conclusions.ts
/**
 * Reasoning level: 'explicit' conclusions are extracted directly from
 * messages; 'deductive'/'inductive'/'contradiction' are derived during
 * dreaming.
 */
readonly level: ConclusionLevel
```

Verified against a live Honcho 3.0.11 instance — `POST /v3/workspaces/{id}/conclusions/list` returns:

```json
{
  "id": "dTecvFzuSm3838v7aadlG",
  "content": "...",
  "observer_id": "claude",
  "observed_id": "claude",
  "session_id": "dudul-openconcho",
  "level": "deductive",
  "created_at": "2026-08-03T21:56:40.252268Z"
}
```

Across 800 conclusions on that instance: 740 `explicit`, 31 `deductive`, 29 `inductive` — all of which the dashboard was rendering as explicit.

## Fix

Read `level`. Two details beyond the rename:

**`contradiction` is a fourth level.** A naive `c.level ?? "explicit"` would pass it straight through and crash two call sites that assume a closed 3-value set:

- `DreamDetail.tsx` — `buckets[inferConclusionType(c)].push(c)` on a bucket record with only three keys → `TypeError` on `undefined.push`
- `PremiseTree.tsx` — `TYPE_BADGE[type]` → `TypeError` reading `cfg.bg`

So `contradiction` is added as a first-class type: detail column, badge, and a list chip that stays hidden at zero (the three existing chips keep rendering dimmed at zero as before).

**Unknown levels no longer reach the UI.** `level` is typed `string`, not the union, and narrowed through `CONCLUSION_TYPES`. If Honcho adds a fifth level, the conclusion is counted as explicit instead of crashing the page or vanishing from the totals.

## Notes for review

- **`e2e/dreams.spec.ts` has ~70 lines of re-indent noise.** `pnpm lint` is `biome check src/`, so `e2e/` was never formatted; the `.husky/pre-commit` hook (`biome check --write --staged`) reformatted the whole file when the mock rename was staged. No logic changed there beyond `conclusion_type:` → `level:`. Happy to strip it if you'd rather keep the diff to the five renamed lines.
- **`openapi.json` is Honcho 3.0.5, which exposes neither field**, so `ExtendedConclusion` is still needed. Regenerating against a newer spec would let `level` become a first-class typed field and drop the augmentation — left alone here since that's a bigger call.
- **`premises` and `reasoning_tree` are genuinely unserved.** A full conclusion object from live 3.0.11 has exactly seven keys; neither field appears on the list or detail response. `expandPremiseTree` and `PremiseTree` therefore never render children today. Left untouched — separate concern from this fix.
- Honcho `main` has since renamed `observer_id` → `observer` in `src/schemas/api.py`, so a future API bump will need a wider sweep than this.

## Verification

- `pnpm check` (lint + typecheck + test) passes
- `packages/web/src/test/dreams.test.ts` — 15 tests pass, including a new case asserting an unrecognized level counts as explicit rather than being dropped
- Confirmed in a running dashboard against the live instance above: dream cards now show `5 deductive`, `6 deductive / 9 inductive`, `6 inductive` for three consecutive runs whose raw API timestamps and levels match exactly
