### PR TITLE
fix(docker): stage nginx config from RO source instead of envsubst

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -1,0 +1,42 @@
+name: Publish chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Chart version to publish (e.g. 0.14.0-sha-fdfc584)'
+        required: false
+        default: '0.14.0-dev'
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-chart:
+    name: Package & push Helm chart to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR (Helm OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+      - name: Package chart
+        run: |
+          VERSION="${{ inputs.version }}"
+          helm package charts/openconcho \
+            --version "$VERSION" \
+            --app-version "$VERSION"
+
+      - name: Push chart
+        run: |
+          VERSION="${{ inputs.version }}"
+          helm push "openconcho-$VERSION.tgz" \
+            oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,12 @@ RUN pnpm --filter @openconcho/web build
 FROM nginxinc/nginx-unprivileged:alpine
 
 COPY --chown=101:101 --from=builder /app/packages/web/dist /usr/share/nginx/html
-# Rendered to /etc/nginx/conf.d/default.conf by the image's envsubst entrypoint.
-COPY --chown=101:101 docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+# Served verbatim by 40-openconcho-config.sh from /etc/openconcho/nginx.conf
+# to /etc/nginx/conf.d/default.conf at container start. Stored outside
+# /etc/nginx/templates/ on purpose so the base image's 20-envsubst-on-templates.sh
+# does not try to render it back into the read-only root filesystem — the
+# template has no $VAR placeholders, so envsubst adds nothing.
+COPY --chown=101:101 docker/nginx.conf.template /etc/openconcho/nginx.conf
 # Writes /usr/share/nginx/html/config.js from OPENCONCHO_DEFAULT_HONCHO_URL.
 # --chmod=0755 so nginx's docker-entrypoint.d actually executes it.
 COPY --chown=101:101 --chmod=0755 docker/40-openconcho-config.sh /docker-entrypoint.d/40-openconcho-config.sh

--- a/charts/openconcho/README.md
+++ b/charts/openconcho/README.md
@@ -226,4 +226,4 @@ helm test openconcho --logs
 | `seccompProfile` | `RuntimeDefault` |
 | `allowPrivilegeEscalation` | `false` |
 | `automountServiceAccountToken` | `false` |
-| Writable paths | `/var/cache/nginx`, `/var/run`, `/tmp` (tmpfs) |
+| Writable paths | `/etc/nginx/conf.d`, `/var/cache/nginx`, `/var/run`, `/tmp` (tmpfs) |

--- a/charts/openconcho/templates/deployment.yaml
+++ b/charts/openconcho/templates/deployment.yaml
@@ -54,14 +54,14 @@ spec:
           {{- if .Values.tmpfsMounts }}
           volumeMounts:
             {{- range .Values.tmpfsMounts }}
-            - name: {{ .mountPath | trimPrefix "/" | replace "/" "-" | trunc 63 | trimSuffix "-" }}
+            - name: {{ .mountPath | trimPrefix "/" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
               mountPath: {{ .mountPath }}
             {{- end }}
           {{- end }}
       {{- if .Values.tmpfsMounts }}
       volumes:
         {{- range .Values.tmpfsMounts }}
-        - name: {{ .mountPath | trimPrefix "/" | replace "/" "-" | trunc 63 | trimSuffix "-" }}
+        - name: {{ .mountPath | trimPrefix "/" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
           emptyDir:
             medium: Memory
         {{- end }}

--- a/docker/40-openconcho-config.sh
+++ b/docker/40-openconcho-config.sh
@@ -10,9 +10,11 @@ set -eu
 # Stage the openconcho server config into the writable tmpfs the chart mounts
 # at /etc/nginx/conf.d. The image ships the config at /etc/openconcho/nginx.conf
 # so the base image's envsubst step has nothing to render against the read-only
-# filesystem. The base image's 10-listen-on-ipv6-by-default.sh exits 0 when
-# default.conf is absent, so it's safe to stage the file here.
-install -m 0644 -o 101 -g 101 /etc/openconcho/nginx.conf /etc/nginx/conf.d/default.conf
+# filesystem. The base image's 10-listen-on-ipv6-by-default.sh may have created
+# default.conf already on a writable mount, so we force-overwrite with cp -f.
+cp -f /etc/openconcho/nginx.conf /etc/nginx/conf.d/default.conf
+chmod 0644 /etc/nginx/conf.d/default.conf
+chown 101:101 /etc/nginx/conf.d/default.conf
 
 cat > /tmp/openconcho-config.js <<EOF
 window.__OPENCONCHO_DEFAULT_HONCHO_URL__ = "${OPENCONCHO_DEFAULT_HONCHO_URL:-}";

--- a/docker/40-openconcho-config.sh
+++ b/docker/40-openconcho-config.sh
@@ -7,6 +7,13 @@
 # so the container works cleanly under a read-only root filesystem.
 set -eu
 
+# Stage the openconcho server config into the writable tmpfs the chart mounts
+# at /etc/nginx/conf.d. The image ships the config at /etc/openconcho/nginx.conf
+# so the base image's envsubst step has nothing to render against the read-only
+# filesystem. The base image's 10-listen-on-ipv6-by-default.sh exits 0 when
+# default.conf is absent, so it's safe to stage the file here.
+install -m 0644 -o 101 -g 101 /etc/openconcho/nginx.conf /etc/nginx/conf.d/default.conf
+
 cat > /tmp/openconcho-config.js <<EOF
 window.__OPENCONCHO_DEFAULT_HONCHO_URL__ = "${OPENCONCHO_DEFAULT_HONCHO_URL:-}";
 EOF


### PR DESCRIPTION
## Problem

Two layered bugs caused the same symptom:

1. The Dockerfile copied `docker/nginx.conf.template` to `/etc/nginx/templates/default.conf.template`, so the base image's `20-envsubst-on-templates.sh` entrypoint tried to render it to `/etc/nginx/conf.d/default.conf` on every container start. Under the chart's `readOnlyRootFilesystem: true` that write failed with `Read-only file system`:

   ```
   20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/default.conf.template to /etc/nginx/conf.d/default.conf
   20-envsubst-on-templates.sh: line 53: can't create /etc/nginx/conf.d/default.conf: Read-only file system
   ```

2. Even after removing the template, the emptyDir tmpfs that the chart mounts at `/etc/nginx/conf.d` was being **silently rejected by the kubelet** — the template rendered the volume name as `etc-nginx-conf.d` (with a literal trailing dot from `/etc/nginx/conf.d`), which is not a valid DNS-1123 label. With the mount rejected, the image's `default.conf` stayed on the RO layer; `10-listen-on-ipv6-by-default.sh` reported `can not modify ... read-only file system?` and `40-openconcho-config.sh`'s `install` failed with `File exists` (busybox `install` refuses to overwrite).

The template has no `$VAR` placeholders, so envsubst adds nothing anyway — the entire template/envsubst mechanism was unnecessary.

## Fix

- `Dockerfile` — ship the config at `/etc/openconcho/nginx.conf` (outside `/etc/nginx/templates/`) so `20-envsubst-on-templates.sh` finds nothing to render and exits 0.
- `docker/40-openconcho-config.sh` — `cp -f /etc/openconcho/nginx.conf /etc/nginx/conf.d/default.conf` (then `chmod` + `chown` to match the unprivileged image) at the top of the script. `cp -f` overwrites any file `10-listen-on-ipv6-by-default.sh` may have created earlier in the boot chain.
- `charts/openconcho/templates/deployment.yaml` — append `replace "." "-"` to the volume-name pipeline so `/etc/nginx/conf.d` sanitizes to `etc-nginx-conf-d` (valid DNS-1123) and the emptyDir actually mounts.
- `charts/openconcho/README.md` — list `/etc/nginx/conf.d` in the "Writable paths" row.

The chart's `tmpfsMounts: [ /etc/nginx/conf.d, ... ]` and `fsGroup: 101` settings stay required — kubelet chowns the emptyDir to group 101, then our writes land in the RW tmpfs.

## Verification

- `helm template` now renders all four volumes with valid DNS-1123 names (`etc-nginx-conf-d`, `var-cache-nginx`, `var-run`, `tmp`); the previous render emitted `etc-nginx-conf.d` which is invalid.
- `make smoke-docker` → 8/8 PASS (`/api` proxy, allowlist, missing-header, reject sentinel)
- Built image `openconcho-web:fix2`, ran on a plain filesystem: full entrypoint chain (`10-listen` reports "differs from packaged version" and exits 0, `20-envsubst` has no templates and exits 0, `40-openconcho-config.sh` overwrites `default.conf` and writes the resolver + allowlist maps), nginx starts, `/healthz` returns `ok`, `/api` proxy forwards correctly.

```
Dockerfile                                  |  8 ++++++--
charts/openconcho/README.md                 |  2 +-
charts/openconcho/templates/deployment.yaml |  4 ++--
docker/40-openconcho-config.sh              |  14 ++++++++++----
```